### PR TITLE
Some changes to take into account PhotometricInterpretation

### DIFF
--- a/src/dicom/dicomParser.js
+++ b/src/dicom/dicomParser.js
@@ -450,6 +450,12 @@ dwv.dicom.DicomParser.prototype.getImage = function()
         columnSpacing, rowSpacing);
     // image
     var image = new dwv.image.Image( size, spacing, this.pixelBuffer );
+    // photometricInterpretation
+    var photometricInterpretation = 'MONOCHROME2';
+    if( this.dicomElements.PhotometricInterpretation ) {
+        photometricInterpretation = this.dicomElements.PhotometricInterpretation.value[0].trim();
+    }        
+    image.setPhotometricInterpretation(photometricInterpretation);
     // lookup
     var slope = 1;
     if( this.dicomElements.RescaleSlope ) {

--- a/src/image/reader.js
+++ b/src/image/reader.js
@@ -22,15 +22,19 @@ dwv.image.getDataFromImage = function(image, file)
     var buffer = [];
     var r, g, b, value;
     var j = 0;
+    var startTime = new Date();
+    var auxCoef = 255 / 16777216;
     for( var i = 0; i < imageData.data.length; i+=4 ) {
         r = imageData.data[i];
         g = imageData.data[i+1];
         b = imageData.data[i+2];
         value = 65536 * r + 256 * g + b;
-        value = Math.floor(value * 255 / 16777216);
+        value = Math.floor(value * auxCoef);
         buffer[j] = value;
         ++j;
     }
+    var deltaTime = new Date() - startTime;
+    console.log('getDataFromImage: ' + deltaTime);
     // create dwv Image
     var imageSize = new dwv.image.ImageSize(image.width, image.height);
     // TODO: wrong info...


### PR DESCRIPTION
I have made some changes in order to take into account the PhotometricInterpretation field. In particular, the viewer can now open RGB images (tested with some ultrasound images).

The case for MONOCHROME2 was the default one and it is working as previously. In the case of MONOCHROME1, some changes are required in order to get an inverse image. These changes can be made when reading data from the raw buffer or when applying the LUT transformation. I have let it undone so you can complete that accordingly to your particular preferences.

![dwv_us_color](https://f.cloud.github.com/assets/929672/443361/203bd9ea-b17c-11e2-8473-e8905403f8aa.png)
