### PR TITLE
Display properly RGB images having Planar Configuration = 1

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -298,13 +298,34 @@ dwv.image.Image.prototype.generateImageData = function( array, sliceNumber )
         break;
         
         case "RGB":
-            var posBuffer = 0;
+            // dummy code to force Planar Configuration = 1
+            // Please read and assign this value (0028, 0006) as any other Dicom Element
+            var planarConfiguration = 1;
+        
+            var posR, posG, posB, stepPos;
+            if (planarConfiguration == 1) { // RRRR...GGGG...BBBB...
+              posR = 0;
+              posG = iMax;
+              posB = 2 * iMax;
+              stepPos = 1;
+            }
+            else { // RGBRGBRGBRGB...
+              posR = 0;
+              posG = 1;
+              posB = 2;
+              stepPos = 3;
+            }
+
             for(var i=sliceOffset; i < iMax; ++i)
             {        
-                array.data[4*i] = this.buffer[posBuffer++];
-                array.data[4*i+1] = this.buffer[posBuffer++];
-                array.data[4*i+2] = this.buffer[posBuffer++];
+                array.data[4*i] = this.buffer[posR];
+                array.data[4*i+1] = this.buffer[posG];
+                array.data[4*i+2] = this.buffer[posB];
                 array.data[4*i+3] = 0xff;
+
+                posR += stepPos;
+                posG += stepPos;
+                posB += stepPos;
             }
         break;
         


### PR DESCRIPTION
I have made some changes in order to take into account the byte ordering in RGB images for any Planar Configuration value (issue #31). Screenshot attached.

You should add the necessary code to read and store the value of that Dicom Element (0028, 0006).

 José Antonio

![RGB_PlanarConfiguration_1](https://f.cloud.github.com/assets/929672/452852/773bcc22-b2fe-11e2-8585-648bfba95995.png)
