### PR TITLE
some patches for dicomWriter support of u/l length 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,10 +34,7 @@ module.exports = function(grunt) {
         },
         concat: {
             options: {
-                separator: ';',
-                banner: '(function() {var dwv = (function() {',
-                footer: 'return dwv;})();if (typeof module !== \'undefined\' && typeof module.exports !== \'undefined\')module.exports = dwv;else window.dwv = dwv;})();',
-                sourceMap: true
+                separator: ';'
             },
             dist: {
                 src: ['src/**/*.js'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,10 @@ module.exports = function(grunt) {
         },
         concat: {
             options: {
-                separator: ';'
+                separator: ';',
+                banner: '(function() {var dwv = (function() {',
+                footer: 'return dwv;})();if (typeof module !== \'undefined\' && typeof module.exports !== \'undefined\')module.exports = dwv;else window.dwv = dwv;})();',
+                sourceMap: true
             },
             dist: {
                 src: ['src/**/*.js'],

--- a/src/dicom/dicomParser.js
+++ b/src/dicom/dicomParser.js
@@ -659,8 +659,8 @@ dwv.dicom.getTypedArray = function (bitsAllocated, pixelRepresentation, size)
 dwv.dicom.is32bitVLVR = function (vr)
 {
     // added locally used 'ox'
-    return ( vr === "OB" || vr === "OW" || vr === "OF" || vr === "ox" ||
-            vr === "SQ" || vr === "UN" );
+    return ( vr === "OB" || vr === "OW" || vr === "OF" || vr === "ox" ||  vr === "UT" ||
+    vr === "SQ" || vr === "UN" );
 };
 
 /**
@@ -848,6 +848,7 @@ dwv.dicom.DicomParser.prototype.readPixelItemDataElement = function (reader, off
 
     // first item: basic offset table
     var item = this.readDataElement(reader, offset, implicit);
+    var offsetVl = item.vl;
     offset = item.endOffset;
 
     // read until the sequence delimitation item
@@ -863,7 +864,8 @@ dwv.dicom.DicomParser.prototype.readPixelItemDataElement = function (reader, off
 
     return {
         'data': itemData,
-        'endOffset': offset };
+        'endOffset': offset,
+        'offsetVl': offsetVl };
 };
 
 /**
@@ -937,6 +939,7 @@ dwv.dicom.DicomParser.prototype.readDataElement = function (reader, offset, impl
     {
         var pixItemData = this.readPixelItemDataElement(reader, offset, implicit);
         offset = pixItemData.endOffset;
+        startOffset += pixItemData.offsetVl;
         data = pixItemData.data;
     }
     else if (isPixelData && (vr === "OB" || vr === "OW" || vr === "OF" || vr === "ox")) {

--- a/src/dicom/dicomWriter.js
+++ b/src/dicom/dicomWriter.js
@@ -319,8 +319,15 @@ dwv.dicom.DataWriter.prototype.writeDataElementValue = function (vr, byteOffset,
     if ( vr === "OB" || vr === "UN") {
         byteOffset = this.writeUint8Array(byteOffset, value);
     }
-    else if ( vr === "US" || vr === "OW") {
+    else if ( vr === "US") {
         byteOffset = this.writeUint16Array(byteOffset, value);
+    }
+    else if (vr === "OW") {
+        if (value.BYTES_PER_ELEMENT === 1) {
+            byteOffset = this.writeUint8Array(byteOffset, value);
+        } else {
+            byteOffset = this.writeUint16Array(byteOffset, value);
+        }
     }
     else if ( vr === "SS") {
         byteOffset = this.writeInt16Array(byteOffset, value);


### PR DESCRIPTION
Hi there, 
I created some patches to your branch, I hope you find them helpful and would merge the pull request: 
1) in some files I noticed, that "UT" vr is not parsed correctly, since it should be a 32 bit vl vr according to dicom.nema.org
2) I add the length of the first item to the startOffset of the pixel sequence. That way, if for some reason the basic offset item has a length of not 0, we still calculate the correct length of the pixel sequence. Otherwise, the length of the basic offset would be left unused in the buffer and cause errors in parsing afterwards.
3) I would also like to propose to add a footer and a header in grunt concat task to be able to use dwv in node require function, it is then easier to test for example.