### PR TITLE
Add generated folder and package installed folder to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.settings
+build
+node_modules
+bower_components


### PR DESCRIPTION
This PR may prevent git from tracking too many generated and installed files in local development environment.