### PR TITLE
Add decode to import the export data which have been encode

### DIFF
--- a/src/app/drawController.js
+++ b/src/app/drawController.js
@@ -313,7 +313,7 @@ dwv.DrawController = function (drawDiv)
                     "frame": position.frameNumber,
                     "type": type,
                     "color": shape.stroke(),
-                    "label": decodeURIComponent()(text.textExpr),
+                    "label": decodeURIComponent(text.textExpr),
                     "description": text.longText
                 });
             }

--- a/src/app/drawController.js
+++ b/src/app/drawController.js
@@ -410,7 +410,7 @@ dwv.DrawController = function (drawDiv)
                     var label = stateGroup.getChildren( dwv.draw.isNodeNameLabel )[0];
                     var text = label.getText();
                     // store details
-                    text.textExpr = decodeURIComponent()(details.textExpr);
+                    text.textExpr = decodeURIComponent(details.textExpr);
                     text.longText = details.longText;
                     text.quant = details.quant;
                     // reset text (it was not encoded)

--- a/src/app/drawController.js
+++ b/src/app/drawController.js
@@ -313,7 +313,7 @@ dwv.DrawController = function (drawDiv)
                     "frame": position.frameNumber,
                     "type": type,
                     "color": shape.stroke(),
-                    "label": text.textExpr,
+                    "label": decodeURIComponent()(text.textExpr),
                     "description": text.longText
                 });
             }
@@ -410,7 +410,7 @@ dwv.DrawController = function (drawDiv)
                     var label = stateGroup.getChildren( dwv.draw.isNodeNameLabel )[0];
                     var text = label.getText();
                     // store details
-                    text.textExpr = details.textExpr;
+                    text.textExpr = decodeURIComponent()(details.textExpr);
                     text.longText = details.longText;
                     text.quant = details.quant;
                     // reset text (it was not encoded)


### PR DESCRIPTION
The text.textExpr have been encode in line 354, so when I used the export data to show the graph, it will not shown correctly. I think it need to be decode before import.