### PR TITLE
Error writing embedded pixeldata sequence

### DIFF
--- a/src/dicom/dicomWriter.js
+++ b/src/dicom/dicomWriter.js
@@ -542,6 +542,11 @@ dwv.dicom.isImplicitLengthPixels = function (element) {
 dwv.dicom.flattenArrayOfTypedArrays = function(initialArray) {
     var initialArrayLength = initialArray.length;
     var arrayLength = initialArray[0].length;
+    // If this is not a array of arrays, just return the initial one:
+    if (arrayLength === undefined) {
+        return initialArray;
+    }
+
     var flattenendArrayLength = initialArrayLength * arrayLength;
 
     var flattenedArray = new initialArray[0].constructor(flattenendArrayLength);

--- a/src/dicom/dicomWriter.js
+++ b/src/dicom/dicomWriter.js
@@ -543,7 +543,7 @@ dwv.dicom.flattenArrayOfTypedArrays = function(initialArray) {
     var initialArrayLength = initialArray.length;
     var arrayLength = initialArray[0].length;
     // If this is not a array of arrays, just return the initial one:
-    if (arrayLength === undefined) {
+    if (typeof arrayLength === "undefined") {
         return initialArray;
     }
 


### PR DESCRIPTION
When writing dicom files with a sequence containing pixeldata the method flattenArrayOfTypedArrays is not working properly.

I actually wanted to write a unit test but I did not get it right how to manage the DICOM file under test which should be located in your repo.

This file contains an example
[000000.zip](https://github.com/ivmartel/dwv/files/2105253/000000.zip)


