### PR TITLE
Attempt to parse Dicom files without metadata

### DIFF
--- a/src/dicom/dicomParser.js
+++ b/src/dicom/dicomParser.js
@@ -1297,7 +1297,7 @@ dwv.dicom.DicomParser.prototype.parse = function (buffer)
             throw new Error("Not a valid DICOM file (no magic DICM word found and first element not in 0x0008 group)");
         }
         var vr0 = dataElement.vr.charCodeAt(0);
-        var vr1 = dataElement.vr.charCodeAt(0);
+        var vr1 = dataElement.vr.charCodeAt(1);
         implicit = (vr0 >= 65 && vr0 <= 90 && vr1 >= 65 && vr1 <= 90) ? false : true;  // reasonable assumption: 2 uppercase characters = implicit
         if (dataElement.tag.group == "0x0800") { // big endian
             if (implicit) { // ImplicitVRBigEndian

--- a/src/dicom/dicomParser.js
+++ b/src/dicom/dicomParser.js
@@ -1280,6 +1280,7 @@ dwv.dicom.DicomParser.prototype.parse = function (buffer)
     var offset = 0;
     var implicit = false;
     var syntax = "";
+    var dataElement = null;
     // default readers
     var metaReader = new dwv.dicom.DataReader(buffer);
     var dataReader = new dwv.dicom.DataReader(buffer);
@@ -1332,7 +1333,7 @@ dwv.dicom.DicomParser.prototype.parse = function (buffer)
     else {  // metadata parsing
 
         // 0x0002, 0x0000: FileMetaInformationGroupLength
-        var dataElement = this.readDataElement(metaReader, offset, false);
+        dataElement = this.readDataElement(metaReader, offset, false);
         offset = dataElement.endOffset;
         // store the data element
         this.dicomElements[dataElement.tag.name] = dataElement;


### PR DESCRIPTION
In case of a Dicom file without metadata, check that first element is in 0x0008 group. If successful, check for the presence or not of two upper-case characters for explicit/implicit VR, and generate transfer syntax element.