### PR TITLE
Get toolbox controller

### DIFF
--- a/src/app/application.js
+++ b/src/app/application.js
@@ -142,6 +142,12 @@ dwv.App = function ()
     this.getViewController = function () { return viewController; };
 
     /**
+     * Get the toolbox controller.
+     * @return {Object} The controller.
+     */
+    this.getToolboxController = function () { return toolboxController; };
+
+    /**
      * Get the draw controller.
      * @return {Object} The controller.
      */


### PR DESCRIPTION
In a case we want to manipulate the tool directly such as zooming while doing drawing.

We need access to toolbox in order to do so.