### PR TITLE
Updated gitignore to avoid package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 # misc
 npm-debug.log
 yarn-error.log
+package-lock.json


### PR DESCRIPTION
Added package-lock.json to gitignore to avoid unwanted pushes after fork / npm install commands.