### PR TITLE
image loader fix in case of origin is string (url)

### DIFF
--- a/src/image/domReader.js
+++ b/src/image/domReader.js
@@ -83,6 +83,8 @@ dwv.image.getViewFromDOMImage = function (image, origin)
     // image properties
     var info = [];
     if ( typeof image.origin === "string" ) {
+        info.push({ "name": "fileName", "value": "" });
+        info.push({ "name": "fileType", "value": "" });
         info.push({ "name": "origin", "value": image.origin });
     } else {
         info.push({ "name": "fileName", "value": image.origin.name });


### PR DESCRIPTION
if the image origin is string still info array should have 5 objects so that it doesn't break on "infocontroller.js line no 79" where it gets  the value from data[5] variable

ivmartel/dwv#777