### PR TITLE
1459 fix orientation

### DIFF
--- a/src/app/application.js
+++ b/src/app/application.js
@@ -1699,34 +1699,60 @@ export class App {
 
     // major orientation axis
     const major = imageGeometry.getOrientation().getThirdColMajorDirection();
+    const rowAbsMax0 = imageGeometry.getOrientation().getRowAbsMax(0).value;
+    const rowAbsMax1 = imageGeometry.getOrientation().getRowAbsMax(1).value;
 
-    // flip
+    // flip flags
     let flipOffsetX = false;
     let flipOffsetY = false;
     let flipScaleZ = false;
-    if (typeof viewConfig.orientation !== 'undefined') {
-      if (major === 2) {
-        // scale flip Z for oriented views...
-        flipScaleZ = true;
-        // flip offset Y for axial aquired data
-        if (viewConfig.orientation !== 'axial') {
-          flipOffsetY = true;
-        }
-      } else if (major === 0) {
-        // scale flip Z for oriented views...
-        flipScaleZ = true;
-        // flip offset X for sagittal aquired data
-        if (viewConfig.orientation !== 'sagittal') {
+
+    if (major === 0) {
+      // sagittal case
+      // TODO: find other examples than bbmri
+      flipScaleZ = true;
+      if (typeof viewConfig.orientation !== 'undefined' &&
+        viewConfig.orientation !== 'sagittal') {
+        flipOffsetX = true;
+      }
+    } else if (major === 1) {
+      // coronal case
+      // TODO: find examples
+    } else if (major === 2) {
+      // axial case
+      // TODO: find an all negative test case
+      if (typeof viewConfig.orientation === 'undefined' ||
+        viewConfig.orientation === 'axial') {
+        if (rowAbsMax0 < 0) {
           flipOffsetX = true;
         }
-      }
-    } else {
-      if (major === 0) {
-        // scale flip Z for sagittal and undefined target orientation
+        if (rowAbsMax1 < 0) {
+          flipOffsetY = true;
+        }
+      } else {
         flipScaleZ = true;
+        if (rowAbsMax0 > 0 && rowAbsMax1 > 0) {
+          flipOffsetY = true;
+        }
+        if (viewConfig.orientation === 'coronal') {
+          if (rowAbsMax0 < 0) {
+            flipOffsetX = true;
+            if (rowAbsMax1 < 0) {
+              flipOffsetY = true;
+            }
+          }
+        } else if (viewConfig.orientation === 'sagittal') {
+          if (rowAbsMax1 < 0) {
+            flipOffsetX = true;
+            if (rowAbsMax0 < 0) {
+              flipOffsetY = true;
+            }
+          }
+        }
       }
     }
-    // apply
+
+    // apply flips
     if (flipOffsetX) {
       viewLayer.addFlipOffsetX();
       if (typeof drawLayer !== 'undefined') {

--- a/src/app/application.js
+++ b/src/app/application.js
@@ -1706,6 +1706,8 @@ export class App {
     let flipOffsetX = false;
     let flipOffsetY = false;
     let flipScaleZ = false;
+    let flipScaleY = false;
+    let flipScaleX = false;
 
     if (major === 0) {
       // sagittal case
@@ -1744,7 +1746,54 @@ export class App {
       }
     } else if (major === 1) {
       // coronal case
-      // TODO: find examples
+      if (typeof viewConfig.orientation === 'undefined' ||
+        viewConfig.orientation === 'coronal') {
+        if (colAbsMax0 < 0) {
+          flipOffsetX = true;
+          flipScaleX = true;
+          if (colAbsMax1 > 0) {
+            flipOffsetY = true;
+            flipScaleZ = true;
+          }
+        }
+        if (colAbsMax1 > 0) {
+          flipOffsetY = true;
+          flipScaleZ = true;
+        }
+      } else {
+        // specific
+        if (viewConfig.orientation === 'axial') {
+          if (colAbsMax0 < 0 && colAbsMax1 > 0) {
+            flipOffsetX = true;
+            flipScaleX = true;
+          }
+          if (colAbsMax0 < 0 && colAbsMax1 < 0) {
+            flipOffsetX = true;
+            flipScaleX = true;
+            flipOffsetY = true;
+            flipScaleY = true;
+          }
+          if (colAbsMax0 > 0 && colAbsMax1 > 0) {
+            flipOffsetY = true;
+            flipScaleY = true;
+          }
+        } else if (viewConfig.orientation === 'sagittal') {
+          if (colAbsMax0 < 0 && colAbsMax1 > 0) {
+            flipOffsetY = true;
+            flipScaleZ = true;
+          }
+          if (colAbsMax0 < 0 && colAbsMax1 < 0) {
+            flipOffsetX = true;
+            flipScaleY = true;
+          }
+          if (colAbsMax0 > 0 && colAbsMax1 > 0) {
+            flipOffsetX = true;
+            flipOffsetY = true;
+            flipScaleY = true;
+            flipScaleZ = true;
+          }
+        }
+      }
     } else if (major === 2) {
       // axial case
       if (typeof viewConfig.orientation === 'undefined' ||
@@ -1789,6 +1838,18 @@ export class App {
       viewLayer.addFlipOffsetY();
       if (typeof drawLayer !== 'undefined') {
         drawLayer.addFlipOffsetY();
+      }
+    }
+    if (flipScaleX) {
+      viewLayer.flipScaleX();
+      if (typeof drawLayer !== 'undefined') {
+        drawLayer.flipScaleX();
+      }
+    }
+    if (flipScaleY) {
+      viewLayer.flipScaleY();
+      if (typeof drawLayer !== 'undefined') {
+        drawLayer.flipScaleY();
       }
     }
     if (flipScaleZ) {

--- a/src/app/application.js
+++ b/src/app/application.js
@@ -1720,7 +1720,6 @@ export class App {
       // TODO: find examples
     } else if (major === 2) {
       // axial case
-      // TODO: find an all negative test case
       if (typeof viewConfig.orientation === 'undefined' ||
         viewConfig.orientation === 'axial') {
         if (rowAbsMax0 < 0) {

--- a/src/app/application.js
+++ b/src/app/application.js
@@ -1699,8 +1699,8 @@ export class App {
 
     // major orientation axis
     const major = imageGeometry.getOrientation().getThirdColMajorDirection();
-    const rowAbsMax0 = imageGeometry.getOrientation().getRowAbsMax(0).value;
-    const rowAbsMax1 = imageGeometry.getOrientation().getRowAbsMax(1).value;
+    const colAbsMax0 = imageGeometry.getOrientation().getColAbsMax(0).value;
+    const colAbsMax1 = imageGeometry.getOrientation().getColAbsMax(1).value;
 
     // flip flags
     let flipOffsetX = false;
@@ -1709,11 +1709,38 @@ export class App {
 
     if (major === 0) {
       // sagittal case
-      // TODO: find other examples than bbmri
-      flipScaleZ = true;
-      if (typeof viewConfig.orientation !== 'undefined' &&
-        viewConfig.orientation !== 'sagittal') {
-        flipOffsetX = true;
+      if (typeof viewConfig.orientation === 'undefined' ||
+        viewConfig.orientation === 'sagittal') {
+        flipScaleZ = true;
+        if (colAbsMax0 < 0) {
+          flipOffsetX = true;
+        }
+        if (colAbsMax1 > 0) {
+          flipOffsetY = true;
+        }
+      } else {
+        // common
+        if (colAbsMax0 > 0 && colAbsMax1 < 0) {
+          flipOffsetX = true;
+        }
+        if (colAbsMax0 < 0 && colAbsMax1 > 0) {
+          flipOffsetX = true;
+          flipOffsetY = true;
+        }
+        // specific
+        if (viewConfig.orientation === 'axial') {
+          if (colAbsMax0 > 0) {
+            flipScaleZ = true;
+          }
+          if (colAbsMax0 < 0 && colAbsMax1 < 0) {
+            flipOffsetY = true;
+          }
+        } else if (viewConfig.orientation === 'coronal') {
+          flipScaleZ = true;
+          if (colAbsMax0 > 0 && colAbsMax1 > 0) {
+            flipOffsetY = true;
+          }
+        }
       }
     } else if (major === 1) {
       // coronal case
@@ -1722,30 +1749,30 @@ export class App {
       // axial case
       if (typeof viewConfig.orientation === 'undefined' ||
         viewConfig.orientation === 'axial') {
-        if (rowAbsMax0 < 0) {
+        if (colAbsMax0 < 0) {
           flipOffsetX = true;
         }
-        if (rowAbsMax1 < 0) {
+        if (colAbsMax1 < 0) {
           flipOffsetY = true;
         }
       } else {
+        // common
         flipScaleZ = true;
-        if (rowAbsMax0 > 0 && rowAbsMax1 > 0) {
+        if (colAbsMax0 > 0 && colAbsMax1 > 0) {
           flipOffsetY = true;
         }
+        if (colAbsMax0 < 0 && colAbsMax1 < 0) {
+          flipOffsetX = true;
+          flipOffsetY = true;
+        }
+        // specific
         if (viewConfig.orientation === 'coronal') {
-          if (rowAbsMax0 < 0) {
+          if (colAbsMax0 < 0 && colAbsMax1 > 0) {
             flipOffsetX = true;
-            if (rowAbsMax1 < 0) {
-              flipOffsetY = true;
-            }
           }
         } else if (viewConfig.orientation === 'sagittal') {
-          if (rowAbsMax1 < 0) {
+          if (colAbsMax0 > 0 && colAbsMax1 < 0) {
             flipOffsetX = true;
-            if (rowAbsMax0 < 0) {
-              flipOffsetY = true;
-            }
           }
         }
       }

--- a/src/gui/drawLayer.js
+++ b/src/gui/drawLayer.js
@@ -239,6 +239,20 @@ export class DrawLayer {
   }
 
   /**
+   * Flip the scale along the layer X axis.
+   */
+  flipScaleX() {
+    this.#flipScale.x *= -1;
+  }
+
+  /**
+   * Flip the scale along the layer Y axis.
+   */
+  flipScaleY() {
+    this.#flipScale.y *= -1;
+  }
+
+  /**
    * Flip the scale along the layer Z axis.
    */
   flipScaleZ() {

--- a/src/gui/viewLayer.js
+++ b/src/gui/viewLayer.js
@@ -350,6 +350,20 @@ export class ViewLayer {
   }
 
   /**
+   * Flip the scale along the layer X axis.
+   */
+  flipScaleX() {
+    this.#flipScale.x *= -1;
+  }
+
+  /**
+   * Flip the scale along the layer Y axis.
+   */
+  flipScaleY() {
+    this.#flipScale.y *= -1;
+  }
+
+  /**
    * Flip the scale along the layer Z axis.
    */
   flipScaleZ() {


### PR DESCRIPTION
Fixes #1459.

Previously supported orientations:
axial: 1 0 0 0 1 0 (RAI)
coronal: 1 0 0 0 0 -1 (RSP)
sagittal: 0 1 0 0 0 -1 (ASL)

The orientation code maps the pixel coordinate system I (column) J (row) K (slice) to right-handed coordinate system X Y Z. Characters R (right), L (left), A (anterior), P (posterior), I (inferior), S (superior) identify from direction.

RAI, the default orientation, means
- X: patient Right to left
- Y: patient Anterior to posterior
- Z: patient Inferior to superior

Reference: https://www.aliza-dicom-viewer.com/manual/orientation, https://www.slicer.org/wiki/Coordinate_systems

This PR aims at fixing the following orientations.

Axial
-----------------
ALI: 0 1 0 -1 0 0
ARI: 0 1 0 1 0 0
LAI: -1 0 0 0 1 0 -> OK
LPI: -1 0 0 0 -1 0 -> OK
PLI: 0 -1 0 -1 0 0
PRI: 0 -1 0 1 0 0
RAI: 1 0 0 0 1 0 -> OK
RPI: 1 0 0 0 -1 0 -> OK

Coronal
-----------------
ILP: 0 0 1 -1 0 0
IRP: 0 0 1 1 0 0
LIP: -1 0 0 0 0 1 -> OK
LSP: -1 0 0 0 0 -1 -> OK
RIP: 1 0 0 0 0 1 -> OK
RSP: 1 0 0 0 0 -1 -> OK
SLP: 0 0 -1 -1 0 0 
SRP: 0 0 -1 1 0 0

Sagittal
-----------------
AIL: 0 1 0 0 0 1 -> OK
ASL: 0 1 0 0 0 -1 -> OK
IAL: 0 0 1 0 1 0
IPL: 0 0 1 0 -1 0
PIL: 0 -1 0 0 0 1 -> OK
PSL: 0 -1 0 0 0 -1 -> OK
SAL: 0 0 -1 0 1 0
SPL: 0 0 -1 0 -1 0
