### PR TITLE
prevent segmentations without seg labels from failing to load

### DIFF
--- a/src/image/maskFactory.js
+++ b/src/image/maskFactory.js
@@ -316,7 +316,7 @@ function getSegment(dataElements) {
   // algorithmType -> SegmentAlgorithmType (type1)
   const segment = {
     number: dataElements['00620004'].value[0],
-    label: dataElements['00620005'].value[0],
+    label: dataElements['00620005'] ? dataElements['00620005'].value[0] : 'n/a',
     algorithmType: dataElements['00620008'].value[0]
   };
   // algorithmName -> SegmentAlgorithmName (type1C)


### PR DESCRIPTION
tag (0062,0005) is type 1 and therefore segments should have this tag set. Nevertheless, having no label tag should not break loading the dicom since it doesn't compromise the application