### PR TITLE
additional tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tcdwv1",
+  "name": "dwv",
   "version": "0.33.0-beta.38",
-  "description": "Test Custom DICOM Web Viewer.",
+  "description": "DICOM Web Viewer.",
   "keywords": [
     "DICOM",
     "medical",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "dwv",
+  "name": "tcdwv1",
   "version": "0.33.0-beta.38",
-  "description": "DICOM Web Viewer.",
+  "description": "Test Custom DICOM Web Viewer.",
   "keywords": [
     "DICOM",
     "medical",

--- a/src/tools/draw.js
+++ b/src/tools/draw.js
@@ -582,7 +582,7 @@ export class Draw {
       tmpPoints, this.#style, viewController);
 
     // skip if select draw
-    if (this.#tmpShapeGroup) {
+    if (!this.#tmpShapeGroup) {
       return;
     }
 

--- a/src/tools/draw.js
+++ b/src/tools/draw.js
@@ -580,6 +580,12 @@ export class Draw {
     const viewController = viewLayer.getViewController();
     this.#tmpShapeGroup = this.#currentFactory.create(
       tmpPoints, this.#style, viewController);
+
+    // skip if select draw
+    if (this.#tmpShapeGroup) {
+      return;
+    }
+
     // do not listen during creation
     const shape = this.#tmpShapeGroup.getChildren(isNodeNameShape)[0];
     shape.listening(false);
@@ -612,6 +618,12 @@ export class Draw {
     // create final shape
     const finalShapeGroup = this.#currentFactory.create(
       finalPoints, this.#style, viewController);
+
+    // skip if select draw
+    if (!finalShapeGroup) {
+      return;
+    }
+
     finalShapeGroup.id(guid());
 
     // get the position group

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -5,7 +5,12 @@ import {Opacity} from './opacity';
 import {Draw} from './draw';
 import {Floodfill} from './floodfill';
 import {Livewire} from './livewire';
+import {ZoomIn} from './zoomIn';
+import {ZoomOut} from './zoomOut';
+import {Pan} from './pan';
 
+
+import {Select} from './select';
 import {ArrowFactory} from './arrow';
 import {CircleFactory} from './circle';
 import {EllipseFactory} from './ellipse';
@@ -33,7 +38,10 @@ export const defaultToolList = {
   Draw,
   Filter,
   Floodfill,
-  Livewire
+  Livewire,
+  ZoomIn,
+  ZoomOut,
+  Pan,
 };
 
 export const toolOptions = {
@@ -45,7 +53,8 @@ export const toolOptions = {
     ProtractorFactory,
     RectangleFactory,
     RoiFactory,
-    RulerFactory
+    RulerFactory,
+    SelectFactory: Select,
   },
   filter: {
     Threshold,

--- a/src/tools/pan.js
+++ b/src/tools/pan.js
@@ -1,0 +1,249 @@
+import {Point2D} from '../math/point';
+import {getLayerDetailsFromEvent} from '../gui/layerGroup';
+import {getMousePoint, getTouchPoints} from '../gui/generic';
+
+// doc imports
+/* eslint-disable no-unused-vars */
+import {App} from '../app/application';
+import {Line} from '../math/line';
+/* eslint-enable no-unused-vars */
+
+/**
+ * Pan class.
+ *
+ * @example
+ * // create the dwv app
+ * const app = new dwv.App();
+ * // initialise
+ * const viewConfig0 = new dwv.ViewConfig('layerGroup0');
+ * const viewConfigs = {'*': [viewConfig0]};
+ * const options = new dwv.AppOptions(viewConfigs);
+ * options.tools = {Pan: new dwv.ToolConfig()};
+ * app.init(options);
+ * // activate tool
+ * app.addEventListener('load', function () {
+ *   app.setTool('Pan');
+ * });
+ * // load dicom data
+ * app.loadURLs([
+ *   'https://raw.githubusercontent.com/ivmartel/dwv/master/tests/data/bbmri-53323851.dcm'
+ * ]);
+ */
+export class Pan {
+  /**
+   * Associated app.
+   *
+   * @type {App}
+   */
+  #app;
+
+  /**
+   * Interaction start flag.
+   *
+   * @type {boolean}
+   */
+  #started = false;
+
+  /**
+   * Start point.
+   *
+   * @type {Point2D}
+   */
+  #startPoint;
+
+  /**
+   * Line between input points.
+   *
+   * @type {Line}
+   */
+  #pointsLine;
+
+  /**
+   * PointsLine midpoint.
+   *
+   * @type {Point2D}
+   */
+  #midPoint;
+
+  /**
+   * @param {App} app The associated application.
+   */
+  constructor(app) {
+    this.#app = app;
+  }
+
+  /**
+   * Start tool interaction.
+   *
+   * @param {Point2D} point The start point.
+   */
+  #start(point) {
+    this.#started = true;
+    this.#startPoint = point;
+  }
+
+  /**
+   * Two touch start.
+   *
+   * @param {Point2D[]} points The start points.
+   */
+  #twoTouchStart = (points) => {
+    this.#started = true;
+    this.#startPoint = points[0];
+    // points line
+    this.#pointsLine = new Line(points[0], points[1]);
+    this.#midPoint = this.#pointsLine.getMidpoint();
+  };
+
+  /**
+   * Update tool interaction.
+   *
+   * @param {Point2D} point The update point.
+   * @param {string} divId The layer group divId.
+   */
+  #update(point, divId) {
+    if (!this.#started) {
+      return;
+    }
+
+    // calculate translation
+    const tx = point.getX() - this.#startPoint.getX();
+    const ty = point.getY() - this.#startPoint.getY();
+    // apply translation
+    const layerGroup = this.#app.getLayerGroupByDivId(divId);
+    const viewLayer = layerGroup.getActiveViewLayer();
+    const viewController = viewLayer.getViewController();
+    const planeOffset = viewLayer.displayToPlaneScale(new Point2D(tx, ty));
+    const offset3D = viewController.getOffset3DFromPlaneOffset({
+      x: planeOffset.getX(),
+      y: planeOffset.getY(),
+    });
+    layerGroup.addTranslation({
+      x: offset3D.getX(),
+      y: offset3D.getY(),
+      z: offset3D.getZ(),
+    });
+    layerGroup.draw();
+    // reset origin point
+    this.#startPoint = point;
+  }
+
+  /**
+   * Finish tool interaction.
+   */
+  #finish() {
+    if (this.#started) {
+      this.#started = false;
+    }
+  }
+
+  /**
+   * Handle mouse down event.
+   *
+   * @param {object} event The mouse down event.
+   */
+  mousedown = (event) => {
+    const mousePoint = getMousePoint(event);
+    this.#start(mousePoint);
+  };
+
+  /**
+   * Handle mouse move event.
+   *
+   * @param {object} event The mouse move event.
+   */
+  mousemove = (event) => {
+    const mousePoint = getMousePoint(event);
+    const layerDetails = getLayerDetailsFromEvent(event);
+    this.#update(mousePoint, layerDetails.groupDivId);
+  };
+
+  /**
+   * Handle mouse up event.
+   *
+   * @param {object} _event The mouse up event.
+   */
+  mouseup = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle mouse out event.
+   *
+   * @param {object} _event The mouse out event.
+   */
+  mouseout = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle touch start event.
+   *
+   * @param {object} event The touch start event.
+   */
+  touchstart = (event) => {
+    const touchPoints = getTouchPoints(event);
+    if (touchPoints.length === 1) {
+      this.#start(touchPoints[0]);
+    } else if (touchPoints.length === 2) {
+      this.#twoTouchStart(touchPoints);
+    }
+  };
+
+  /**
+   * Handle touch move event.
+   *
+   * @param {object} event The touch move event.
+   */
+  touchmove = (event) => {
+    const touchPoints = getTouchPoints(event);
+    const layerDetails = getLayerDetailsFromEvent(event);
+    if (touchPoints.length === 1) {
+      this.#update(touchPoints[0], layerDetails.groupDivId);
+    }
+  };
+
+  /**
+   * Handle touch end event.
+   *
+   * @param {object} _event The touch end event.
+   */
+  touchend = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle key down event.
+   *
+   * @param {object} event The key down event.
+   */
+  keydown = (event) => {
+    event.context = 'Pan';
+    this.#app.onKeydown(event);
+  };
+
+  /**
+   * Activate the tool.
+   *
+   * @param {boolean} _bool The flag to activate or not.
+   */
+  activate(_bool) {
+    // does nothing
+  }
+
+  /**
+   * Initialise the tool.
+   */
+  init() {
+    // does nothing
+  }
+
+  /**
+   * Set the tool live features: does nothing.
+   *
+   * @param {object} _features The list of features.
+   */
+  setFeatures(_features) {
+    // does nothing
+  }
+} // Pan class

--- a/src/tools/select.js
+++ b/src/tools/select.js
@@ -2,8 +2,10 @@
 
 // doc imports
 /* eslint-disable no-unused-vars */
+import Konva from 'konva';
 import {ViewController} from '../app/viewController';
 import {Style} from '../gui/style';
+import {Point2D} from '../math/point';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -41,9 +43,9 @@ export class Select {
   /**
    * Create an arrow shape to be displayed.
    *
-   * @param {Point2D[]} points The points from which to extract the line.
-   * @param {Style} style The drawing style.
-   * @param {ViewController} viewController The associated view controller.
+   * @param {Point2D[]} _points The points from which to extract the line.
+   * @param {Style} _style The drawing style.
+   * @param {ViewController} _viewController The associated view controller.
    * @returns {Konva.Group} The Konva group.
    */
   create(_points, _style, _viewController) {
@@ -56,8 +58,8 @@ export class Select {
   /**
    * Update an arrow shape.
    *
-   * @param {Konva.Ellipse} anchor The active anchor.
-   * @param {Style} style The app style.
+   * @param {Konva.Ellipse} _anchor The active anchor.
+   * @param {Style} _style The app style.
    * @param {ViewController} _viewController The associated view controller.
    */
   update(_anchor, _style, _viewController) {

--- a/src/tools/select.js
+++ b/src/tools/select.js
@@ -1,0 +1,67 @@
+// import {defaults} from '../app/defaults';
+
+// doc imports
+/* eslint-disable no-unused-vars */
+import {ViewController} from '../app/viewController';
+import {Style} from '../gui/style';
+/* eslint-enable no-unused-vars */
+
+/**
+ * Arrow factory.
+ */
+export class Select {
+  /**
+   * Get the name of the shape group.
+   *
+   * @returns {string} The name.
+   */
+  getGroupName() {
+    return 'select-group';
+  }
+
+  /**
+   * Get the number of points needed to build the shape.
+   *
+   * @returns {number} The number of points.
+   */
+  getNPoints() {
+    return 2;
+  }
+
+  /**
+   * Is the input group a group of this factory?
+   *
+   * @param {Konva.Group} group The group to test.
+   * @returns {boolean} True if the group is from this fcatory.
+   */
+  isFactoryGroup(group) {
+    return this.getGroupName() === group.name();
+  }
+
+  /**
+   * Create an arrow shape to be displayed.
+   *
+   * @param {Point2D[]} points The points from which to extract the line.
+   * @param {Style} style The drawing style.
+   * @param {ViewController} viewController The associated view controller.
+   * @returns {Konva.Group} The Konva group.
+   */
+  create(_points, _style, _viewController) {
+    // const group = new Konva.Group();
+    // group.name(this.getGroupName());
+    // group.visible(true); // dont inherit
+    return null;
+  }
+
+  /**
+   * Update an arrow shape.
+   *
+   * @param {Konva.Ellipse} anchor The active anchor.
+   * @param {Style} style The app style.
+   * @param {ViewController} _viewController The associated view controller.
+   */
+  update(_anchor, _style, _viewController) {
+    // does nothing
+  }
+
+} // class Select

--- a/src/tools/zoomIn.js
+++ b/src/tools/zoomIn.js
@@ -1,0 +1,245 @@
+import {Line} from '../math/line';
+import {getLayerDetailsFromEvent} from '../gui/layerGroup';
+import {
+  getMousePoint,
+  getTouchPoints
+} from '../gui/generic';
+
+// doc imports
+/* eslint-disable no-unused-vars */
+import {App} from '../app/application';
+/* eslint-enable no-unused-vars */
+
+/**
+ * ZoomIn class.
+ *
+ * @example
+ * // create the dwv app
+ * const app = new dwv.App();
+ * // initialise
+ * const viewConfig0 = new dwv.ViewConfig('layerGroup0');
+ * const viewConfigs = {'*': [viewConfig0]};
+ * const options = new dwv.AppOptions(viewConfigs);
+ * options.tools = {ZoomIn: new dwv.ToolConfig()};
+ * app.init(options);
+ * // activate tool
+ * app.addEventListener('load', function () {
+ *   app.setTool('ZoomIn');
+ * });
+ * // load dicom data
+ * app.loadURLs([
+ *   'https://raw.githubusercontent.com/ivmartel/dwv/master/tests/data/bbmri-53323851.dcm'
+ * ]);
+ */
+export class ZoomIn {
+
+  /**
+   * Associated app.
+   *
+   * @type {App}
+   */
+  #app;
+
+  /**
+   * Interaction start flag.
+   *
+   * @type {boolean}
+   */
+  #started = false;
+
+  /**
+   * Line between input points.
+   *
+   * @type {Line}
+   */
+  #pointsLine;
+
+  /**
+   * PointsLine midpoint.
+   *
+   * @type {Point2D}
+   */
+  #midPoint;
+
+  /**
+   * @param {App} app The associated application.
+   */
+  constructor(app) {
+    this.#app = app;
+  }
+
+  /**
+   * Start tool interaction.
+   *
+   * @param {Point2D} point The start point.
+   */
+  #start(_point) {
+    this.#started = true;
+  }
+
+  /**
+   * Two touch start.
+   *
+   * @param {Point2D[]} points The start points.
+   */
+  #twoTouchStart = (points) => {
+    this.#started = true;
+    // points line
+    this.#pointsLine = new Line(points[0], points[1]);
+    this.#midPoint = this.#pointsLine.getMidpoint();
+  };
+
+  /**
+   * Update tool interaction.
+   *
+   * @param {Point2D} point The update point.
+   * @param {string} divId The layer group divId.
+   */
+  #update(_point, _divId) {
+    // does nothing
+  }
+
+  /**
+   * Finish tool interaction.
+   */
+  #finish() {
+    if (this.#started) {
+      this.#started = false;
+    }
+  }
+
+  /**
+   * Handle mouse down event.
+   *
+   * @param {object} event The mouse down event.
+   */
+  mousedown = (event) => {
+    const mousePoint = getMousePoint(event);
+    this.#start(mousePoint);
+
+    // zoom in
+    const layerDetails = getLayerDetailsFromEvent(event);
+    const layerGroup = this.#app.getLayerGroupByDivId(layerDetails.groupDivId);
+    const viewLayer = layerGroup.getActiveViewLayer();
+    const viewController = viewLayer.getViewController();
+    const planePos = viewLayer.displayToMainPlanePos(mousePoint);
+    const center = viewController.getPlanePositionFromPlanePoint(planePos);
+    layerGroup.addScale(0.1, center);
+    layerGroup.draw();
+  };
+
+  /**
+   * Handle mouse move event.
+   *
+   * @param {object} event The mouse move event.
+   */
+  mousemove = (event) => {
+    const mousePoint = getMousePoint(event);
+    const layerDetails = getLayerDetailsFromEvent(event);
+    this.#update(mousePoint, layerDetails.groupDivId);
+  };
+
+  /**
+   * Handle mouse up event.
+   *
+   * @param {object} _event The mouse up event.
+   */
+  mouseup = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle mouse out event.
+   *
+   * @param {object} _event The mouse out event.
+   */
+  mouseout = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle touch start event.
+   *
+   * @param {object} event The touch start event.
+   */
+  touchstart = (event) => {
+    const touchPoints = getTouchPoints(event);
+    if (touchPoints.length === 1) {
+      this.#start(touchPoints[0]);
+    } else if (touchPoints.length === 2) {
+      this.#twoTouchStart(touchPoints);
+    }
+  };
+
+  /**
+   * Handle touch end event.
+   *
+   * @param {object} _event The touch end event.
+   */
+  touchend = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle mouse wheel event.
+   *
+   * @param {object} event The mouse wheel event.
+   */
+  wheel = (event) => {
+    // prevent default page scroll
+    event.preventDefault();
+
+    const step = -event.deltaY / 500;
+
+    // draw on zoom in
+    // if (step > 0) {
+    const layerDetails = getLayerDetailsFromEvent(event);
+    const mousePoint = getMousePoint(event);
+
+    const layerGroup =
+      this.#app.getLayerGroupByDivId(layerDetails.groupDivId);
+    const viewLayer = layerGroup.getActiveViewLayer();
+    const viewController = viewLayer.getViewController();
+    const planePos = viewLayer.displayToMainPlanePos(mousePoint);
+    const center = viewController.getPlanePositionFromPlanePoint(planePos);
+    layerGroup.addScale(step, center);
+    layerGroup.draw();
+    // }
+  };
+
+  /**
+   * Handle key down event.
+   *
+   * @param {object} event The key down event.
+   */
+  keydown = (event) => {
+    event.context = 'ZoomIn';
+    this.#app.onKeydown(event);
+  };
+
+  /**
+   * Activate the tool.
+   *
+   * @param {boolean} _bool The flag to activate or not.
+   */
+  activate(_bool) {
+    // does nothing
+  }
+
+  /**
+   * Initialise the tool.
+   */
+  init() {
+    // does nothing
+  }
+
+  /**
+   * Set the tool live features: does nothing.
+   *
+   * @param {object} _features The list of features.
+   */
+  setFeatures(_features) {
+    // does nothing
+  }
+
+} // ZoomIn class

--- a/src/tools/zoomIn.js
+++ b/src/tools/zoomIn.js
@@ -8,6 +8,7 @@ import {
 // doc imports
 /* eslint-disable no-unused-vars */
 import {App} from '../app/application';
+import {Point2D} from '../math/point';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -71,7 +72,7 @@ export class ZoomIn {
   /**
    * Start tool interaction.
    *
-   * @param {Point2D} point The start point.
+   * @param {Point2D} _point The start point.
    */
   #start(_point) {
     this.#started = true;
@@ -92,8 +93,8 @@ export class ZoomIn {
   /**
    * Update tool interaction.
    *
-   * @param {Point2D} point The update point.
-   * @param {string} divId The layer group divId.
+   * @param {Point2D} _point The update point.
+   * @param {string} _divId The layer group divId.
    */
   #update(_point, _divId) {
     // does nothing

--- a/src/tools/zoomOut.js
+++ b/src/tools/zoomOut.js
@@ -8,6 +8,7 @@ import {
 // doc imports
 /* eslint-disable no-unused-vars */
 import {App} from '../app/application';
+import {Point2D} from '../math/point';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -71,7 +72,7 @@ export class ZoomOut {
   /**
    * Start tool interaction.
    *
-   * @param {Point2D} point The start point.
+   * @param {Point2D} _point The start point.
    */
   #start(_point) {
     this.#started = true;
@@ -92,8 +93,8 @@ export class ZoomOut {
   /**
    * Update tool interaction.
    *
-   * @param {Point2D} point The update point.
-   * @param {string} divId The layer group divId.
+   * @param {Point2D} _point The update point.
+   * @param {string} _divId The layer group divId.
    */
   #update(_point, _divId) {
     // does nothing

--- a/src/tools/zoomOut.js
+++ b/src/tools/zoomOut.js
@@ -1,0 +1,245 @@
+import {Line} from '../math/line';
+import {getLayerDetailsFromEvent} from '../gui/layerGroup';
+import {
+  getMousePoint,
+  getTouchPoints
+} from '../gui/generic';
+
+// doc imports
+/* eslint-disable no-unused-vars */
+import {App} from '../app/application';
+/* eslint-enable no-unused-vars */
+
+/**
+ * ZoomOut class.
+ *
+ * @example
+ * // create the dwv app
+ * const app = new dwv.App();
+ * // initialise
+ * const viewConfig0 = new dwv.ViewConfig('layerGroup0');
+ * const viewConfigs = {'*': [viewConfig0]};
+ * const options = new dwv.AppOptions(viewConfigs);
+ * options.tools = {ZoomOut: new dwv.ToolConfig()};
+ * app.init(options);
+ * // activate tool
+ * app.addEventListener('load', function () {
+ *   app.setTool('ZoomOut');
+ * });
+ * // load dicom data
+ * app.loadURLs([
+ *   'https://raw.githubusercontent.com/ivmartel/dwv/master/tests/data/bbmri-53323851.dcm'
+ * ]);
+ */
+export class ZoomOut {
+
+  /**
+   * Associated app.
+   *
+   * @type {App}
+   */
+  #app;
+
+  /**
+   * Interaction start flag.
+   *
+   * @type {boolean}
+   */
+  #started = false;
+
+  /**
+   * Line between input points.
+   *
+   * @type {Line}
+   */
+  #pointsLine;
+
+  /**
+   * PointsLine midpoint.
+   *
+   * @type {Point2D}
+   */
+  #midPoint;
+
+  /**
+   * @param {App} app The associated application.
+   */
+  constructor(app) {
+    this.#app = app;
+  }
+
+  /**
+   * Start tool interaction.
+   *
+   * @param {Point2D} point The start point.
+   */
+  #start(_point) {
+    this.#started = true;
+  }
+
+  /**
+   * Two touch start.
+   *
+   * @param {Point2D[]} points The start points.
+   */
+  #twoTouchStart = (points) => {
+    this.#started = true;
+    // points line
+    this.#pointsLine = new Line(points[0], points[1]);
+    this.#midPoint = this.#pointsLine.getMidpoint();
+  };
+
+  /**
+   * Update tool interaction.
+   *
+   * @param {Point2D} point The update point.
+   * @param {string} divId The layer group divId.
+   */
+  #update(_point, _divId) {
+    // does nothing
+  }
+
+  /**
+   * Finish tool interaction.
+   */
+  #finish() {
+    if (this.#started) {
+      this.#started = false;
+    }
+  }
+
+  /**
+   * Handle mouse down event.
+   *
+   * @param {object} event The mouse down event.
+   */
+  mousedown = (event) => {
+    const mousePoint = getMousePoint(event);
+    this.#start(mousePoint);
+
+    // zoom out
+    const layerDetails = getLayerDetailsFromEvent(event);
+    const layerGroup = this.#app.getLayerGroupByDivId(layerDetails.groupDivId);
+    const viewLayer = layerGroup.getActiveViewLayer();
+    const viewController = viewLayer.getViewController();
+    const planePos = viewLayer.displayToMainPlanePos(mousePoint);
+    const center = viewController.getPlanePositionFromPlanePoint(planePos);
+    layerGroup.addScale(-0.1, center);
+    layerGroup.draw();
+  };
+
+  /**
+   * Handle mouse move event.
+   *
+   * @param {object} event The mouse move event.
+   */
+  mousemove = (event) => {
+    const mousePoint = getMousePoint(event);
+    const layerDetails = getLayerDetailsFromEvent(event);
+    this.#update(mousePoint, layerDetails.groupDivId);
+  };
+
+  /**
+   * Handle mouse up event.
+   *
+   * @param {object} _event The mouse up event.
+   */
+  mouseup = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle mouse out event.
+   *
+   * @param {object} _event The mouse out event.
+   */
+  mouseout = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle touch start event.
+   *
+   * @param {object} event The touch start event.
+   */
+  touchstart = (event) => {
+    const touchPoints = getTouchPoints(event);
+    if (touchPoints.length === 1) {
+      this.#start(touchPoints[0]);
+    } else if (touchPoints.length === 2) {
+      this.#twoTouchStart(touchPoints);
+    }
+  };
+
+  /**
+   * Handle touch end event.
+   *
+   * @param {object} _event The touch end event.
+   */
+  touchend = (_event) => {
+    this.#finish();
+  };
+
+  /**
+   * Handle mouse wheel event.
+   *
+   * @param {object} event The mouse wheel event.
+   */
+  wheel = (event) => {
+    // prevent default page scroll
+    event.preventDefault();
+
+    const step = -event.deltaY / 500;
+
+    // draw on zoom in
+    // if (step < 0) {
+    const layerDetails = getLayerDetailsFromEvent(event);
+    const mousePoint = getMousePoint(event);
+
+    const layerGroup =
+      this.#app.getLayerGroupByDivId(layerDetails.groupDivId);
+    const viewLayer = layerGroup.getActiveViewLayer();
+    const viewController = viewLayer.getViewController();
+    const planePos = viewLayer.displayToMainPlanePos(mousePoint);
+    const center = viewController.getPlanePositionFromPlanePoint(planePos);
+    layerGroup.addScale(step, center);
+    layerGroup.draw();
+    // }
+  };
+
+  /**
+   * Handle key down event.
+   *
+   * @param {object} event The key down event.
+   */
+  keydown = (event) => {
+    event.context = 'ZoomOut';
+    this.#app.onKeydown(event);
+  };
+
+  /**
+   * Activate the tool.
+   *
+   * @param {boolean} _bool The flag to activate or not.
+   */
+  activate(_bool) {
+    // does nothing
+  }
+
+  /**
+   * Initialise the tool.
+   */
+  init() {
+    // does nothing
+  }
+
+  /**
+   * Set the tool live features: does nothing.
+   *
+   * @param {object} _features The list of features.
+   */
+  setFeatures(_features) {
+    // does nothing
+  }
+
+} // ZoomOut class

--- a/tests/pacs/viewer.js
+++ b/tests/pacs/viewer.js
@@ -148,11 +148,11 @@ function viewerSetup() {
     Scroll: {},
     WindowLevel: {},
     ZoomAndPan: {},
-    Opacity: {},
-    Draw: {options: ['Select', 'Ruler', 'Circle', 'Ellipse', 'Rectangle']},
     ZoomIn: {},
     ZoomOut: {},
     Pan: {},
+    Opacity: {},
+    Draw: {options: ['Select', 'Ruler', 'Circle', 'Ellipse', 'Rectangle']},
   };
 
   // app config

--- a/tests/pacs/viewer.js
+++ b/tests/pacs/viewer.js
@@ -149,7 +149,10 @@ function viewerSetup() {
     WindowLevel: {},
     ZoomAndPan: {},
     Opacity: {},
-    Draw: {options: ['Ruler', 'Circle', 'Ellipse', 'Rectangle']}
+    Draw: {options: ['Select', 'Ruler', 'Circle', 'Ellipse', 'Rectangle']},
+    ZoomIn: {},
+    ZoomOut: {},
+    Pan: {},
   };
 
   // app config


### PR DESCRIPTION
hi,

<br/>

continuing my question here https://github.com/ivmartel/dwv/issues/1643, i am about to add some tools that fit my current project. i was just thinking maybe there's other who need this, so i decided to open a pull request.


draw options:
- select: sometimes we want to only select a drawing object to edit the size or position without drawing any shapes. i don't know if this feature already exists or not, but i'll use it for my current project. also, i notice the draw options are all for shapes, and select is not a shape at all. the problem is that i will not be able to select drawing objects if i am not in the drawing layer.

tools:
- zoom-in: zoom-in on mousedown by adding a `0.1` scale step.
- zoom-out: zoom-out on mousedown by adding a `-0.1` scale step.
- pan: pan on mousemove or touchmove.

note:
- zoom-in, zoom-out, and pan are reusing the existing code `zoomPan`. i copy it, then edit it a little.
- for zoom-in and zoom-out, the wheel is still active, so it can either do zoom-in or zoom-out with a click or touch, or zoom-in or zoom-out on the wheel or scroll.
- i only test this on chrome, not sure this is work well on other browser.

<br/>

thanks.