### PR TITLE
Change isValid check in DeleteSegmentCommand

### DIFF
--- a/src/image/deleteSegmentCommand.js
+++ b/src/image/deleteSegmentCommand.js
@@ -48,8 +48,6 @@ export class DeleteSegmentCommand {
   constructor(mask, segment, silent) {
     this.#mask = mask;
     this.#segment = segment;
-   
-
     this.#isSilent = (typeof silent === 'undefined') ? false : silent;
     // list of offsets with the colour to delete
     if (typeof segment.displayRGBValue !== 'undefined') {
@@ -74,8 +72,8 @@ export class DeleteSegmentCommand {
    * @returns {boolean} True if the command is valid.
    */
   isValid() {
-    const segments =  this.#mask.getMeta().custom.segments;    
-    return segments.some(segmentItem => 
+    const segments = this.#mask.getMeta().custom.segments;
+    return segments.some(segmentItem =>
       segmentItem.number === this.#segment.number
     );
   }
@@ -86,7 +84,7 @@ export class DeleteSegmentCommand {
    * @fires DeleteSegmentCommand#masksegmentdelete
    */
   execute() {
-    if(this.#offsets.length !==0){
+    if (this.#offsets.length !== 0) {
       // remove from image
       if (typeof this.#segment.displayRGBValue !== 'undefined') {
         this.#mask.setAtOffsets(this.#offsets, BLACK);
@@ -94,7 +92,7 @@ export class DeleteSegmentCommand {
         this.#mask.setAtOffsets(this.#offsets, 0);
       }
     }
-    
+
     // remove from segments
     const segHelper = new MaskSegmentHelper(this.#mask);
     segHelper.removeSegment(this.#segment.number);
@@ -121,7 +119,7 @@ export class DeleteSegmentCommand {
    * @fires DeleteSegmentCommand#masksegmentredraw
    */
   undo() {
-    if(this.#offsets.length !==0){
+    if (this.#offsets.length !== 0) {
       // re-draw in image
       if (typeof this.#segment.displayRGBValue !== 'undefined') {
         this.#mask.setAtOffsets(this.#offsets, this.#segment.displayRGBValue);

--- a/src/image/deleteSegmentCommand.js
+++ b/src/image/deleteSegmentCommand.js
@@ -48,6 +48,7 @@ export class DeleteSegmentCommand {
   constructor(mask, segment, silent) {
     this.#mask = mask;
     this.#segment = segment;
+   
 
     this.#isSilent = (typeof silent === 'undefined') ? false : silent;
     // list of offsets with the colour to delete
@@ -73,7 +74,10 @@ export class DeleteSegmentCommand {
    * @returns {boolean} True if the command is valid.
    */
   isValid() {
-    return this.#offsets.length !== 0;
+    const segments =  this.#mask.getMeta().custom.segments;    
+    return segments.some(segmentItem => 
+      segmentItem.number === this.#segment.number
+    );
   }
 
   /**
@@ -82,12 +86,15 @@ export class DeleteSegmentCommand {
    * @fires DeleteSegmentCommand#masksegmentdelete
    */
   execute() {
-    // remove from image
-    if (typeof this.#segment.displayRGBValue !== 'undefined') {
-      this.#mask.setAtOffsets(this.#offsets, BLACK);
-    } else {
-      this.#mask.setAtOffsets(this.#offsets, 0);
+    if(this.#offsets.length !==0){
+      // remove from image
+      if (typeof this.#segment.displayRGBValue !== 'undefined') {
+        this.#mask.setAtOffsets(this.#offsets, BLACK);
+      } else {
+        this.#mask.setAtOffsets(this.#offsets, 0);
+      }
     }
+    
     // remove from segments
     const segHelper = new MaskSegmentHelper(this.#mask);
     segHelper.removeSegment(this.#segment.number);
@@ -114,11 +121,13 @@ export class DeleteSegmentCommand {
    * @fires DeleteSegmentCommand#masksegmentredraw
    */
   undo() {
-    // re-draw in image
-    if (typeof this.#segment.displayRGBValue !== 'undefined') {
-      this.#mask.setAtOffsets(this.#offsets, this.#segment.displayRGBValue);
-    } else {
-      this.#mask.setAtOffsets(this.#offsets, this.#segment.displayValue);
+    if(this.#offsets.length !==0){
+      // re-draw in image
+      if (typeof this.#segment.displayRGBValue !== 'undefined') {
+        this.#mask.setAtOffsets(this.#offsets, this.#segment.displayRGBValue);
+      } else {
+        this.#mask.setAtOffsets(this.#offsets, this.#segment.displayValue);
+      }
     }
     // add back to segments
     const segHelper = new MaskSegmentHelper(this.#mask);


### PR DESCRIPTION
The isValid method in DeleteSegmentCommand was avoiding to remove a segment not drawn.
- Change isValid to check if the segment to be deleted is in the segment array
- Move the this.#offsets.length check into execute and undo methods