### PR TITLE
Avoid base layer opacity to be changed

### DIFF
--- a/src/gui/layerGroup.js
+++ b/src/gui/layerGroup.js
@@ -343,27 +343,6 @@ export class LayerGroup {
     return this.#baseScale;
   }
 
-  /**
-   * Get the base layer.
-   *
-   * @returns {ViewLayer|undefined} The base layer.
-   */
-  getBaseLayer() {
-    // use first layer as base for calculating position and
-    // line sizes
-    let baseLayer;
-    for (const layer of this.#layers) {
-      if (layer instanceof ViewLayer) {
-        baseLayer = layer;
-        break;
-      }
-    }
-    if (typeof baseLayer === 'undefined') {
-      logger.warn('No layer found');
-      return;
-    }
-    return baseLayer;
-  }
 
   /**
    * Get the added scale: the scale added to the base scale.

--- a/src/gui/layerGroup.js
+++ b/src/gui/layerGroup.js
@@ -441,11 +441,20 @@ export class LayerGroup {
    * @returns {ViewLayer|undefined} The layer.
    */
   getBaseViewLayer() {
-    let layer;
-    if (this.#layers[0] instanceof ViewLayer) {
-      layer = this.#layers[0];
+    // use first layer as base for calculating position and
+    // line sizes
+    let baseLayer;
+    for (const layer of this.#layers) {
+      if (layer instanceof ViewLayer) {
+        baseLayer = layer;
+        break;
+      }
     }
-    return layer;
+    if (typeof baseLayer === 'undefined') {
+      logger.warn('No layer found');
+      return;
+    }
+    return baseLayer;
   }
 
   /**

--- a/src/gui/layerGroup.js
+++ b/src/gui/layerGroup.js
@@ -344,6 +344,28 @@ export class LayerGroup {
   }
 
   /**
+   * Get the base layer.
+   *
+   * @returns {ViewLayer|undefined} The base layer.
+   */
+  getBaseLayer() {
+    // use first layer as base for calculating position and
+    // line sizes
+    let baseLayer;
+    for (const layer of this.#layers) {
+      if (layer instanceof ViewLayer) {
+        baseLayer = layer;
+        break;
+      }
+    }
+    if (typeof baseLayer === 'undefined') {
+      logger.warn('No layer found');
+      return;
+    }
+    return baseLayer;
+  }
+
+  /**
    * Get the added scale: the scale added to the base scale.
    *
    * @returns {Scalar3D} The scale as {x,y,z}.

--- a/src/gui/stage.js
+++ b/src/gui/stage.js
@@ -140,9 +140,10 @@ export class OpacityBinder {
       if (typeof event.dataid === 'undefined') {
         return;
       }
-      // propagate to first view layer
+      // propagate to first view layer if it is not base layer
       const viewLayers = layerGroup.getViewLayersByDataId(event.dataid);
-      if (viewLayers.length !== 0) {
+      const baseLayer = layerGroup.getBaseLayer();
+      if (viewLayers.length !== 0 && baseLayer !== viewLayers[0]) {
         viewLayers[0].setOpacity(event.value);
         viewLayers[0].draw();
       }

--- a/src/gui/stage.js
+++ b/src/gui/stage.js
@@ -142,7 +142,7 @@ export class OpacityBinder {
       }
       // propagate to first view layer if it is not base layer
       const viewLayers = layerGroup.getViewLayersByDataId(event.dataid);
-      const baseLayer = layerGroup.getBaseLayer();
+      const baseLayer = layerGroup.getBaseViewLayer();
       if (viewLayers.length !== 0 && baseLayer !== viewLayers[0]) {
         viewLayers[0].setOpacity(event.value);
         viewLayers[0].draw();


### PR DESCRIPTION
- Create the getBaseLayer method in layerGroup
- Avoid base layer opacity to be changed by sync