### PR TITLE
 Avoid warning if PET series is also not monochrome or secondary capture

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -16,6 +16,7 @@ import {Matrix33} from '../math/matrix';
 import {NumberRange} from '../math/stats';
 import {DataElement} from '../dicom/dataElement';
 import {RGB} from '../utils/colour';
+import {isMonochrome} from '../dicom/dicomElementsWrapper';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -336,8 +337,7 @@ export class Image {
    * @returns {boolean} True if the data is monochrome.
    */
   isMonochrome() {
-    return this.getPhotometricInterpretation()
-      .match(/MONOCHROME/) !== null;
+    return isMonochrome(this.getPhotometricInterpretation());
   }
 
   /**

--- a/src/image/imageFactory.js
+++ b/src/image/imageFactory.js
@@ -15,7 +15,11 @@ import {
   getPixelUnit,
   TagValueExtractor,
   getSuvFactor,
-  getOrientationMatrix
+  getOrientationMatrix,
+  isSecondatyCapture,
+  getPhotometricInterpretation,
+  getSopClassUid,
+  isMonochrome
 } from '../dicom/dicomElementsWrapper';
 import {Point3D} from '../math/point';
 import {logger} from '../utils/logger';
@@ -74,7 +78,15 @@ export class ImageFactory {
     const element = dataElements['00080060'];
     if (typeof element !== 'undefined') {
       modality = element.value[0];
+
       if (modality === 'PT') {
+        const photometricInterpretation =
+        getPhotometricInterpretation(dataElements);
+        const SOPClassUID = getSopClassUid(dataElements);
+        if (isSecondatyCapture(SOPClassUID) || 
+        !isMonochrome(photometricInterpretation)) {
+          return this.#warning;
+        }
         const suvFactor = getSuvFactor(dataElements);
         this.#suvFactor = suvFactor.value;
         this.#warning = suvFactor.warning;


### PR DESCRIPTION
 - Create methods getSopClassUid, isSecondatyCapture, getPhotometricinterpretation and isMonochrome
- Avoid warning if PET series is also not monochrome or secondary capture
- Reuse monochrome method in image.js