### PR TITLE
Minor fix to world to index conversion

### DIFF
--- a/src/image/geometry.js
+++ b/src/image/geometry.js
@@ -523,11 +523,11 @@ export class Geometry {
       this.getOrientation().getInverse().multiplyPoint3D(point3D);
     // keep >3d values
     const values = point.getValues();
-    // apply spacing and round
+    // apply spacing and floor
     const spacing = this.getSpacing();
-    values[0] = Math.round(orientedPoint3D.getX() / spacing.get(0));
-    values[1] = Math.round(orientedPoint3D.getY() / spacing.get(1));
-    values[2] = Math.round(orientedPoint3D.getZ() / spacing.get(2));
+    values[0] = Math.floor(orientedPoint3D.getX() / spacing.get(0));
+    values[1] = Math.floor(orientedPoint3D.getY() / spacing.get(1));
+    values[2] = Math.floor(orientedPoint3D.getZ() / spacing.get(2));
 
     // return index
     return new Index(values);


### PR DESCRIPTION
Fixes as part of https://github.com/ivmartel/dwv/issues/1871

Change `Geometry.worldToIndex` to use `Math.floor` instead of `Math.round`.

Requires a fair amount of testing before merging to make sure it doesn't break anything