### PR TITLE
refactor binders iteration on remove event listeners

### DIFF
--- a/src/gui/stage.js
+++ b/src/gui/stage.js
@@ -585,12 +585,19 @@ export class Stage {
    * @param {object} binder The layer binder.
    */
   #removeEventListeners(index, binder) {
-    for (let i = 0; i < this.#layerGroups.length; ++i) {
-      if (i !== index && this.#layerGroups[i].shouldBind()) {
-        this.#layerGroups[index].removeEventListener(
-          binder.getEventType(),
-          this.#getBinderCallback(binder, i)
-        );
+    if (!this.#callbackStore) {
+      return;
+    }
+    for (const key in this.#callbackStore) {
+      if (parseInt(key, 10) !== index) {
+        for (const binderObj of this.#callbackStore[key]) {
+          if (binderObj.binder.getEventType() === binder.getEventType()) {
+            this.#layerGroups[index].removeEventListener(
+              binder.getEventType(),
+              binderObj.callback
+            );
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The logic (shouldBind) used when adding the listeners could be different when removing them (for ex when removing layers) leading to incomplete removal. The proposed code removes all the added listeners listed in the callback store.