### PR TITLE
2000 Calculate segmentation diameters

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -25,6 +25,13 @@ export const webpackCommon = {
     // (otherwise clients use file:// scheme creating CORS error)
     workerPublicPath: './'
   },
+  optimization: {
+    splitChunks: {
+      // Stop webpack from trying to use importScript inside webworkers
+      // if any webworkers share imports.
+      chunks: 'initial'
+    }
+  },
   experiments: {
     // module is still experimental
     outputModule: true

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -1712,6 +1712,8 @@ export class Image {
             new Index(label.centroidIndex));
           label.volume = label.count * pixelVolume;
           label.unit = volumeUnit;
+          // diameters should be already in the correct units
+          label.diameterUnit = lengthUnit;
         }
         // sort
         const labelsSorted =
@@ -1733,7 +1735,7 @@ export class Image {
 
     this.#fireEvent({type: 'labelingstart'});
 
-    this.#labelingThread.run(this.#buffer, this.#geometry.getSize());
+    this.#labelingThread.run(this.#buffer, this.#geometry);
   }
 
   /**

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -1725,6 +1725,9 @@ export class Image {
           type: 'labelschanged',
           labels: labelsSorted
         });
+
+        this.#buffer = event.data.buffer;
+        this.#fireEvent({type: 'imagecontentchange'});
       };
     }
 

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -26,6 +26,49 @@ import {Point} from '../math/point.js';
 const ML_PER_MM = 0.001; // ml/mm^3
 
 /**
+ * Unit value.
+ *
+ * @typedef UnitValue
+ * @property {number} value The value.
+ * @property {string} unit The unit of the value.
+ */
+
+/**
+ * Diameter type.
+ *
+ * @typedef Diameter
+ * @property {UnitValue} diameter The scaled diameter value.
+ * @property {number} offset1 The offset of the pixel at the start
+ *  of the line used to calculate this diameter.
+ * @property {number} offset2 The offset of the pixel at the end
+ *  of the line used to calculate this diameter.
+ */
+
+/**
+ * Diameters type.
+ *
+ * @typedef Diameters
+ * @property {Diameter} major The major (longest) diameter of the segment.
+ * @property {Diameter} minor The minor (longest perpendicular to the major)
+ *  diameter of the segment.
+ */
+
+/**
+ * Label type.
+ *
+ * @typedef Label
+ * @property {Point} centroid The world coordinates of the centroid.
+ * @property {number[]} centroidIndex The closest voxel Index to the centroid.
+ * @property {UnitValue} volume The volume of the labeled segment.
+ * @property {number} count The voxel count of the labeled segment.
+ * @property {Diameters} diameters The diameters of the segment.
+ * @property {UnitValue} height The scaled height of the segment.
+ * @property {number} id The segment label id.
+ * @property {number} largestSliceZ The Z index of the largest slice of the
+ *  segment.
+ */
+
+/**
  * List of image event names.
  *
  * @type {string[]}
@@ -1710,12 +1753,26 @@ export class Image {
         for (const label of labels) {
           label.centroid = this.#geometry.indexToWorld(
             new Index(label.centroidIndex));
-          label.volume = label.count * pixelVolume;
-          label.unit = volumeUnit;
+          label.volume = {
+            value: label.count * pixelVolume,
+            unit: volumeUnit
+          };
           // diameters should be already in the correct units
-          label.diameterUnit = lengthUnit;
+          label.diameters.major.diameter = {
+            value: label.diameters.major.diameter,
+            unit: lengthUnit
+          };
+          label.diameters.minor.diameter = {
+            value: label.diameters.minor.diameter,
+            unit: lengthUnit
+          };
+          label.height = {
+            value: label.height,
+            unit: lengthUnit
+          };
         }
         // sort
+        /** @type {Label[]} */
         const labelsSorted =
           labels.sort((v1, v2) => {
             return v2.volume - v1.volume;
@@ -1728,8 +1785,14 @@ export class Image {
           labels: labelsSorted
         });
 
-        this.#buffer = event.data.buffer;
-        this.#fireEvent({type: 'imagecontentchange'});
+        //TODO: This is temporary until a proper method of displaying
+        // diameters is implmented.
+        // ------
+        if (event.data.buffer) {
+          this.#buffer = event.data.buffer;
+          this.#fireEvent({type: 'imagecontentchange'});
+        }
+        // ------
       };
     }
 

--- a/src/image/labeling.worker.js
+++ b/src/image/labeling.worker.js
@@ -8,7 +8,8 @@ self.addEventListener('message', function (event) {
 
   const filter = new LabelingFilter();
   self.postMessage({
-    labels: filter.run(event.data)
+    labels: filter.run(event.data),
+    buffer: event.data.imageBuffer
   });
 
 }, false);

--- a/src/image/labeling.worker.js
+++ b/src/image/labeling.worker.js
@@ -7,9 +7,6 @@ import {LabelingFilter} from './labelingFilter.js';
 self.addEventListener('message', function (event) {
 
   const filter = new LabelingFilter();
-  self.postMessage({
-    labels: filter.run(event.data),
-    buffer: event.data.imageBuffer
-  });
+  self.postMessage(filter.run(event.data));
 
 }, false);

--- a/src/image/labelingDebug.js
+++ b/src/image/labelingDebug.js
@@ -1,3 +1,10 @@
+import {Point2D} from '../math/point.js';
+
+// doc imports
+/* eslint-disable no-unused-vars */
+import {Line} from '../math/line.js';
+/* eslint-enable no-unused-vars */
+
 /**
  * Helper for the LabelingFilter, provides a debug display for diameters and
  * contours.
@@ -22,8 +29,7 @@ export class LabelingDebug {
   /**
    * Convert a slice local world coordinate to a slice local offset value.
    *
-   * @param {object} point Point on the slice, scaled.
-   *  (object with the structure {x, y}).
+   * @param {Point2D} point Point on the slice, scaled.
    * @param {number[]} unitVectors The unit vectors for index to offset
    *  conversion.
    * @param {number[]} spacing The pixel spacing of the image.
@@ -32,8 +38,8 @@ export class LabelingDebug {
    */
   #sliceWorldToSliceOffset(point, unitVectors, spacing) {
     const offset =
-      (unitVectors[0] * Math.round(point.x / spacing[0])) +
-      (unitVectors[1] * Math.round(point.y / spacing[1]));
+      (unitVectors[0] * Math.round(point.getX() / spacing[0])) +
+      (unitVectors[1] * Math.round(point.getY() / spacing[1]));
 
     return offset;
   }
@@ -46,22 +52,21 @@ export class LabelingDebug {
    * @param {number[]} unitVectors The unit vectors for index to offset
    *  conversion.
    * @param {number[]} spacing The pixel spacing of the image.
-   * @param {number} x0 The x of the first endpoint of the line segment.
-   * @param {number} y0 The y of the first endpoint of the line segment.
-   * @param {number} x1 The x of the second endpoint of the line segment.
-   * @param {number} y1 The y of the second endpoint of the line segment.
+   * @param {Line} line The line segment to plot.
    * @param {number} z The slice index.
    */
-  #plotLineLow(imageBuffer, unitVectors, spacing, x0, y0, x1, y1, z) {
-    const dx = x1 - x0;
-    const dy = (y0 < y1) ? y1 - y0 : y0 - y1;
+  #plotLineLow(imageBuffer, unitVectors, spacing, line, z) {
+    const p0 = line.getBegin();
+    const p1 = line.getEnd();
+    const dx = line.getDeltaX();
+    const dy = Math.abs(line.getDeltaY());
     let D = 2 * dy - dx;
-    let y = y0;
-    const yi = (y0 < y1) ? 1 : -1;
+    let y = p0.getY();
+    const yi = (p0.getY() < p1.getY()) ? 1 : -1;
 
-    for (let x = x0; x <= x1; x++) {
+    for (let x = p0.getX(); x <= p1.getX(); x++) {
       const sliceOffset =
-        this.#sliceWorldToSliceOffset({x, y}, unitVectors, spacing);
+        this.#sliceWorldToSliceOffset(new Point2D(x, y), unitVectors, spacing);
       const offset = sliceOffset + (unitVectors[2] * z);
       imageBuffer[offset] = imageBuffer[offset] + 128;
 
@@ -81,22 +86,21 @@ export class LabelingDebug {
    * @param {number[]} unitVectors The unit vectors for index to offset
    *  conversion.
    * @param {number[]} spacing The pixel spacing of the image.
-   * @param {number} x0 The x of the first endpoint of the line segment.
-   * @param {number} y0 The y of the first endpoint of the line segment.
-   * @param {number} x1 The x of the second endpoint of the line segment.
-   * @param {number} y1 The y of the second endpoint of the line segment.
+   * @param {Line} line The line segment to plot.
    * @param {number} z The slice index.
    */
-  #plotLineHigh(imageBuffer, unitVectors, spacing, x0, y0, x1, y1, z) {
-    const dx = (x0 < x1) ? x1 - x0 : x0 - x1;
-    const dy = y1 - y0;
+  #plotLineHigh(imageBuffer, unitVectors, spacing, line, z) {
+    const p0 = line.getBegin();
+    const p1 = line.getEnd();
+    const dx = Math.abs(line.getDeltaX());
+    const dy = line.getDeltaY();
     let D = 2 * dx - dy;
-    let x = x0;
-    const xi = (x0 < x1) ? 1 : -1;
+    let x = p0.getX();
+    const xi = (p0.getX() < p1.getX()) ? 1 : -1;
 
-    for (let y = y0; y <= y1; y++) {
+    for (let y = p0.getY(); y <= p1.getY(); y++) {
       const sliceOffset =
-        this.#sliceWorldToSliceOffset({x, y}, unitVectors, spacing);
+        this.#sliceWorldToSliceOffset(new Point2D(x, y), unitVectors, spacing);
       const offset = sliceOffset + (unitVectors[2] * z);
       imageBuffer[offset] = imageBuffer[offset] + 128;
 
@@ -116,22 +120,19 @@ export class LabelingDebug {
    * @param {number[]} unitVectors The unit vectors for index to offset
    *  conversion.
    * @param {number[]} spacing The pixel spacing of the image.
-   * @param {object} p0 The first endpoint of the line segment.
-   *  (object with the structure {x, y}).
-   * @param {object} p1 The second endpoint of the line segment.
+   * @param {Line} line The line segment to plot.
    * @param {number} z The slice index.
    */
-  #plotPoints(imageBuffer, unitVectors, spacing, p0, p1, z) {
-    if (Math.abs(p1.y - p0.y) < Math.abs(p1.x - p0.x)) {
-      if (p0.x < p1.x) {
+  #plotPoints(imageBuffer, unitVectors, spacing, line, z) {
+    const p0 = line.getBegin();
+    const p1 = line.getEnd();
+    if (Math.abs(line.getDeltaY()) < Math.abs(line.getDeltaX())) {
+      if (p0.getX() < p1.getX()) {
         this.#plotLineLow(
           imageBuffer,
           unitVectors,
           spacing,
-          p0.x,
-          p0.y,
-          p1.x,
-          p1.y,
+          line,
           z
         );
       } else {
@@ -139,23 +140,17 @@ export class LabelingDebug {
           imageBuffer,
           unitVectors,
           spacing,
-          p1.x,
-          p1.y,
-          p0.x,
-          p0.y,
+          line.getFlipped(),
           z
         );
       }
     } else {
-      if (p0.y < p1.y) {
+      if (p0.getY() < p1.getY()) {
         this.#plotLineHigh(
           imageBuffer,
           unitVectors,
           spacing,
-          p0.x,
-          p0.y,
-          p1.x,
-          p1.y,
+          line,
           z
         );
       } else {
@@ -163,10 +158,7 @@ export class LabelingDebug {
           imageBuffer,
           unitVectors,
           spacing,
-          p1.x,
-          p1.y,
-          p0.x,
-          p0.y,
+          line.getFlipped(),
           z
         );
       }
@@ -209,8 +201,7 @@ export class LabelingDebug {
         imageBuffer,
         unitVectors,
         spacing,
-        diameter.major.point1,
-        diameter.major.point2,
+        diameter.major.line,
         diameter.zIndex
       );
 
@@ -219,8 +210,7 @@ export class LabelingDebug {
           imageBuffer,
           unitVectors,
           spacing,
-          diameter.minor.point1,
-          diameter.minor.point2,
+          diameter.minor.line,
           diameter.zIndex
         );
       }

--- a/src/image/labelingDebug.js
+++ b/src/image/labelingDebug.js
@@ -1,0 +1,230 @@
+/**
+ * Helper for the LabelingFilter, provides a debug display for diameters and
+ * contours.
+ *
+ * Temporary until a proper way of rendering them is added.
+ */
+export class LabelingDebug {
+
+  /**
+   * Cleans buffer of debug lines before calculations.
+   *
+   * @param {TypedArray} imageBuffer The image buffer to clean.
+   */
+  cleanBuffer(imageBuffer) {
+    for (let i = 0; i < imageBuffer.length; i++) {
+      if (imageBuffer[i] >= 128) {
+        imageBuffer[i] = imageBuffer[i] - 128;
+      }
+    }
+  }
+
+  /**
+   * Convert a slice local world coordinate to a slice local offset value.
+   *
+   * @param {object} point Point on the slice, scaled.
+   *  (object with the structure {x, y}).
+   * @param {number[]} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number[]} spacing The pixel spacing of the image.
+   *
+   * @returns {number} Offset relative to the offset at the start of the slice.
+   */
+  #sliceWorldToSliceOffset(point, unitVectors, spacing) {
+    const offset =
+      (unitVectors[0] * Math.round(point.x / spacing[0])) +
+      (unitVectors[1] * Math.round(point.y / spacing[1]));
+
+    return offset;
+  }
+
+  /**
+   * Draw a debug line segment of an angle less that 45 degrees.
+   * Points should be in slice world space.
+   *
+   * @param {TypedArray} imageBuffer The image buffer to draw debug lines on.
+   * @param {number[]} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number[]} spacing The pixel spacing of the image.
+   * @param {number} x0 The x of the first endpoint of the line segment.
+   * @param {number} y0 The y of the first endpoint of the line segment.
+   * @param {number} x1 The x of the second endpoint of the line segment.
+   * @param {number} y1 The y of the second endpoint of the line segment.
+   * @param {number} z The slice index.
+   */
+  #plotLineLow(imageBuffer, unitVectors, spacing, x0, y0, x1, y1, z) {
+    const dx = x1 - x0;
+    const dy = (y0 < y1) ? y1 - y0 : y0 - y1;
+    let D = 2 * dy - dx;
+    let y = y0;
+    const yi = (y0 < y1) ? 1 : -1;
+
+    for (let x = x0; x <= x1; x++) {
+      const sliceOffset =
+        this.#sliceWorldToSliceOffset({x, y}, unitVectors, spacing);
+      const offset = sliceOffset + (unitVectors[2] * z);
+      imageBuffer[offset] = imageBuffer[offset] + 128;
+
+      if (D > 0) {
+        y = y + yi;
+        D = D - 2 * dx;
+      }
+      D = D + 2 * dy;
+    }
+  }
+
+  /**
+   * Draw a debug line segment of an angle greater that 45 degrees.
+   * Points should be in slice world space.
+   *
+   * @param {TypedArray} imageBuffer The image buffer to draw debug lines on.
+   * @param {number[]} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number[]} spacing The pixel spacing of the image.
+   * @param {number} x0 The x of the first endpoint of the line segment.
+   * @param {number} y0 The y of the first endpoint of the line segment.
+   * @param {number} x1 The x of the second endpoint of the line segment.
+   * @param {number} y1 The y of the second endpoint of the line segment.
+   * @param {number} z The slice index.
+   */
+  #plotLineHigh(imageBuffer, unitVectors, spacing, x0, y0, x1, y1, z) {
+    const dx = (x0 < x1) ? x1 - x0 : x0 - x1;
+    const dy = y1 - y0;
+    let D = 2 * dx - dy;
+    let x = x0;
+    const xi = (x0 < x1) ? 1 : -1;
+
+    for (let y = y0; y <= y1; y++) {
+      const sliceOffset =
+        this.#sliceWorldToSliceOffset({x, y}, unitVectors, spacing);
+      const offset = sliceOffset + (unitVectors[2] * z);
+      imageBuffer[offset] = imageBuffer[offset] + 128;
+
+      if (D > 0) {
+        x = x + xi;
+        D = D - 2 * dy;
+      }
+      D = D + 2 * dx;
+    }
+  }
+
+  /**
+   * Draw a debug line segment.
+   * Points should be in slice world space.
+   *
+   * @param {TypedArray} imageBuffer The image buffer to draw debug lines on.
+   * @param {number[]} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number[]} spacing The pixel spacing of the image.
+   * @param {object} p0 The first endpoint of the line segment.
+   *  (object with the structure {x, y}).
+   * @param {object} p1 The second endpoint of the line segment.
+   * @param {number} z The slice index.
+   */
+  #plotPoints(imageBuffer, unitVectors, spacing, p0, p1, z) {
+    if (Math.abs(p1.y - p0.y) < Math.abs(p1.x - p0.x)) {
+      if (p0.x < p1.x) {
+        this.#plotLineLow(
+          imageBuffer,
+          unitVectors,
+          spacing,
+          p0.x,
+          p0.y,
+          p1.x,
+          p1.y,
+          z
+        );
+      } else {
+        this.#plotLineLow(
+          imageBuffer,
+          unitVectors,
+          spacing,
+          p1.x,
+          p1.y,
+          p0.x,
+          p0.y,
+          z
+        );
+      }
+    } else {
+      if (p0.y < p1.y) {
+        this.#plotLineHigh(
+          imageBuffer,
+          unitVectors,
+          spacing,
+          p0.x,
+          p0.y,
+          p1.x,
+          p1.y,
+          z
+        );
+      } else {
+        this.#plotLineHigh(
+          imageBuffer,
+          unitVectors,
+          spacing,
+          p1.x,
+          p1.y,
+          p0.x,
+          p0.y,
+          z
+        );
+      }
+    }
+  }
+
+  /**
+   * Renders debug lines for contours and diameters.
+   * The pixel value of the debug lines are the segmentation label of the
+   * segment + 128.
+   *
+   * @param {TypedArray} imageBuffer The image buffer to draw debug lines on.
+   * @param {number[]} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number[]} sizes The image dimensions.
+   * @param {number[]} spacing The pixel spacing of the image.
+   * @param {TypedArray} borders The buffer containing the border pixel arrays.
+   * @param {object} maxDiameters The dictionary of calculated diameters.
+   */
+  drawDebugLines(
+    imageBuffer,
+    unitVectors,
+    sizes,
+    spacing,
+    borders,
+    maxDiameters
+  ) {
+    for (let z = 0; z < sizes[2]; z++) {
+      let borderOffset = 0;
+      while (borders[(unitVectors[2] * z) + borderOffset] > 0) {
+        const offset = borders[(unitVectors[2] * z) + borderOffset];
+        if (imageBuffer[offset] > 0) {
+          imageBuffer[offset] = imageBuffer[offset] + 128;
+        }
+        borderOffset++;
+      }
+    }
+    Object.values(maxDiameters).map((diameter) => {
+      this.#plotPoints(
+        imageBuffer,
+        unitVectors,
+        spacing,
+        diameter.major.point1,
+        diameter.major.point2,
+        diameter.zIndex
+      );
+
+      if (typeof diameter.minor !== 'undefined') {
+        this.#plotPoints(
+          imageBuffer,
+          unitVectors,
+          spacing,
+          diameter.minor.point1,
+          diameter.minor.point2,
+          diameter.zIndex
+        );
+      }
+    });
+  }
+
+} //class LabelingDebug

--- a/src/image/labelingFilter.js
+++ b/src/image/labelingFilter.js
@@ -252,7 +252,7 @@ export class LabelingFilter {
         }
       }
 
-      this.#borders[(unitVectors[2] * z) + borderOffset] = 0;
+      this.#borders[(unitVectors[2] * z) + borderOffset] = -1;
 
     }
   }
@@ -429,7 +429,7 @@ export class LabelingFilter {
       // For now the naive way is fast enough for an initial implementation.
 
       let borderOffset1 = 0;
-      while (this.#borders[zOffset + borderOffset1] > 0) {
+      while (this.#borders[zOffset + borderOffset1] >= 0) {
         const offset1 = this.#borders[zOffset + borderOffset1];
         const label1 = this.#find(this.#labels[offset1]);
         const sliceOffset1 = offset1 - zOffset;
@@ -437,7 +437,7 @@ export class LabelingFilter {
           this.#sliceOffsetToSliceWorld(sliceOffset1, unitVectors, spacing);
 
         let borderOffset2 = 0;
-        while (this.#borders[zOffset + borderOffset2] > 0) {
+        while (this.#borders[zOffset + borderOffset2] >= 0) {
           const offset2 = this.#borders[zOffset + borderOffset2];
           if (offset1 !== offset2) {
             const label2 = this.#find(this.#labels[offset2]);
@@ -494,7 +494,7 @@ export class LabelingFilter {
       // For now the naive way is fast enough for an initial implementation.
 
       let borderOffset1 = 0;
-      while (this.#borders[zOffset + borderOffset1] > 0) {
+      while (this.#borders[zOffset + borderOffset1] >= 0) {
         const offset1 = this.#borders[zOffset + borderOffset1];
         const label1 = this.#find(this.#labels[offset1]);
 
@@ -508,7 +508,7 @@ export class LabelingFilter {
           this.#sliceOffsetToSliceWorld(sliceOffset1, unitVectors, spacing);
 
         let borderOffset2 = 0;
-        while (this.#borders[zOffset + borderOffset2] > 0) {
+        while (this.#borders[zOffset + borderOffset2] >= 0) {
           const offset2 = this.#borders[zOffset + borderOffset2];
           if (offset1 !== offset2) {
             const label2 = this.#find(this.#labels[offset2]);

--- a/src/image/labelingFilter.js
+++ b/src/image/labelingFilter.js
@@ -304,10 +304,13 @@ export class LabelingFilter {
         const index = this.#offsetToIndex(o, unitVectors);
         const info = detailledInfos[labelValue];
         if (typeof info === 'undefined') {
+          const sliceCounts = {};
+          sliceCounts[index[2]] = 1;
           detailledInfos[labelValue] = {
             id: buffer[o],
             sum: index,
             count: 1,
+            sliceCounts: sliceCounts,
             maxZ: index[2],
             minZ: index[2]
           };
@@ -316,6 +319,11 @@ export class LabelingFilter {
           info.sum[1] += index[1];
           info.sum[2] += index[2];
           info.count++;
+          if (typeof info.sliceCounts[index[2]] !== 'undefined') {
+            info.sliceCounts[index[2]]++;
+          } else {
+            info.sliceCounts[index[2]] = 1;
+          }
           info.maxZ = Math.max(info.maxZ, index[2]);
           info.minZ = Math.min(info.minZ, index[2]);
         }
@@ -330,10 +338,32 @@ export class LabelingFilter {
         index[d] = detailledInfo.sum[d] / detailledInfo.count;
       }
 
+      const sliceCounts = Object.entries(detailledInfo.sliceCounts);
+      const largestSliceZ = (() => {
+        if (sliceCounts.length > 1) {
+          const largest =
+            sliceCounts
+              .reduce((
+                [largestSlice, largestCount],
+                [currentSlice, currentCount]
+              ) => {
+                if (currentCount > largestCount) {
+                  return [currentSlice, currentCount];
+                } else {
+                  return [largestSlice, largestCount];
+                }
+              })[0];
+          return Number(largest);
+        } else {
+          return Number(sliceCounts[0][0]);
+        }
+      })();
+
       labelsInfo[label] = {
         id: detailledInfo.id,
         centroidIndex: index,
         count: detailledInfo.count,
+        largestSliceZ: largestSliceZ,
         height: (detailledInfo.maxZ - detailledInfo.minZ + 1) * spacing[2]
       };
     }
@@ -408,6 +438,7 @@ export class LabelingFilter {
    *  conversion.
    * @param {number[]} sizes The image dimensions.
    * @param {number[]} spacing The pixel spacing of the image.
+   * @param {object} labelInfos The quantified labelInfos of the segments.
    *
    * @returns {object} The dictionary of calculated diameters.
    */
@@ -415,7 +446,8 @@ export class LabelingFilter {
     buffer,
     unitVectors,
     sizes,
-    spacing
+    spacing,
+    labelInfos
   ) {
     const maxDiameters = {};
 
@@ -432,49 +464,57 @@ export class LabelingFilter {
       while (this.#borders[zOffset + borderOffset1] >= 0) {
         const offset1 = this.#borders[zOffset + borderOffset1];
         const label1 = this.#find(this.#labels[offset1]);
-        const sliceOffset1 = offset1 - zOffset;
-        const slicePosition1 =
-          this.#sliceOffsetToSliceWorld(sliceOffset1, unitVectors, spacing);
 
-        let borderOffset2 = 0;
-        while (this.#borders[zOffset + borderOffset2] >= 0) {
-          const offset2 = this.#borders[zOffset + borderOffset2];
-          if (offset1 !== offset2) {
-            const label2 = this.#find(this.#labels[offset2]);
+        // We only care about the diameter of the largest slice,
+        // we can skip everything else.
+        if (
+          typeof labelInfos[label1] !== 'undefined' &&
+          labelInfos[label1].largestSliceZ === z
+        ) {
+          const sliceOffset1 = offset1 - zOffset;
+          const slicePosition1 =
+            this.#sliceOffsetToSliceWorld(sliceOffset1, unitVectors, spacing);
 
-            if (label1 === label2) {
-              const sliceOffset2 = offset2 - zOffset;
-              const slicePosition2 =
-                this.#sliceOffsetToSliceWorld(
-                  sliceOffset2,
-                  unitVectors,
-                  spacing
-                );
+          let borderOffset2 = 0;
+          while (this.#borders[zOffset + borderOffset2] >= 0) {
+            const offset2 = this.#borders[zOffset + borderOffset2];
+            if (offset1 !== offset2) {
+              const label2 = this.#find(this.#labels[offset2]);
 
-              const distance =
-                this.#calculateDistance(slicePosition1, slicePosition2);
+              if (label1 === label2) {
+                const sliceOffset2 = offset2 - zOffset;
+                const slicePosition2 =
+                  this.#sliceOffsetToSliceWorld(
+                    sliceOffset2,
+                    unitVectors,
+                    spacing
+                  );
 
-              const maxDiameter = maxDiameters[label1];
-              if (
-                typeof maxDiameter === 'undefined' ||
-                maxDiameter.major.diameter < distance
-              ) {
-                maxDiameters[label1] = {
-                  id: buffer[offset1],
-                  major: {
-                    diameter: distance,
-                    point1: slicePosition1,
-                    point2: slicePosition2,
-                    offset1: offset1,
-                    offset2: offset2,
-                  },
-                  zIndex: z
-                };
+                const distance =
+                  this.#calculateDistance(slicePosition1, slicePosition2);
+
+                const maxDiameter = maxDiameters[label1];
+                if (
+                  typeof maxDiameter === 'undefined' ||
+                  maxDiameter.major.diameter < distance
+                ) {
+                  maxDiameters[label1] = {
+                    id: buffer[offset1],
+                    major: {
+                      diameter: distance,
+                      point1: slicePosition1,
+                      point2: slicePosition2,
+                      offset1: offset1,
+                      offset2: offset2,
+                    },
+                    zIndex: z
+                  };
+                }
               }
             }
-          }
 
-          borderOffset2++;
+            borderOffset2++;
+          }
         }
 
         borderOffset1++;
@@ -600,7 +640,8 @@ export class LabelingFilter {
       imageBuffer,
       unitVectors,
       sizes,
-      spacing
+      spacing,
+      labelsInfo
     );
 
     // This is temporary until a proper method of displaying them is implmented

--- a/src/image/labelingFilter.js
+++ b/src/image/labelingFilter.js
@@ -641,7 +641,9 @@ export class LabelingFilter {
 
             // These are in weird units and aren't helpful to pass back
             delete diameters.major.line;
-            delete diameters.minor.line;
+            if (diameters.minor) {
+              delete diameters.minor.line;
+            }
 
             labelInfo.diameters = diameters;
           }

--- a/src/image/labelingFilter.js
+++ b/src/image/labelingFilter.js
@@ -1,3 +1,8 @@
+import {LabelingDebug} from './labelingDebug.js';
+
+// Set this to true to show the debug contour and diameter display
+const DIAMETER_DEBUG = false;
+
 /**
  * Filter for calculating labels.
  *
@@ -235,10 +240,10 @@ export class LabelingFilter {
 
             // Border check
             if (
-              xValue != thisValue || 
-              yValue != thisValue ||
-              xValuep != thisValue || 
-              yValuep != thisValue 
+              xValue !== thisValue ||
+              yValue !== thisValue ||
+              xValuep !== thisValue ||
+              yValuep !== thisValue
             ) {
               this.#borders[(unitVectors[2] * z) + borderOffset] = thisOffset;
               borderOffset++;
@@ -274,17 +279,19 @@ export class LabelingFilter {
   }
 
   /**
-   * Quantify labels: count items and calculate centroid.
+   * Quantify labels: count items, calculate centroid, and calculate height.
    *
-   * @param {TypedArray} buffer The image buffer to regenerate the labels for.
+   * @param {TypedArray} buffer The image buffer to quantify the labels for.
    * @param {number[]} unitVectors The unit vectors for index to offset
    *  conversion.
+   * @param {number[]} spacing The pixel spacing of the image.
    *
-   * @returns {object[]} The list of quantified labels.
+   * @returns {object} The dictionary of quantified labels.
    */
   #quantifyLabels(
     buffer,
     unitVectors,
+    spacing
   ) {
     const detailledInfos = {};
 
@@ -300,37 +307,53 @@ export class LabelingFilter {
           detailledInfos[labelValue] = {
             id: buffer[o],
             sum: index,
-            count: 1
+            count: 1,
+            maxZ: index[2],
+            minZ: index[2]
           };
         } else {
           info.sum[0] += index[0];
           info.sum[1] += index[1];
           info.sum[2] += index[2];
           info.count++;
+          info.maxZ = Math.max(info.maxZ, index[2]);
+          info.minZ = Math.min(info.minZ, index[2]);
         }
       }
     }
 
-    const labelsInfo =
-      Object.values(detailledInfos).map(
-        (detailledInfo) => {
-          const index = Array(detailledInfo.sum.length).fill(0);
-          for (let d = 0; d < detailledInfo.sum.length; d++) {
-            index[d] = detailledInfo.sum[d] / detailledInfo.count;
-          }
+    const labelsInfo = {};
 
-          return {
-            id: detailledInfo.id,
-            centroidIndex: index,
-            count: detailledInfo.count
-          };
-        }
-      );
+    for (const [label, detailledInfo] of Object.entries(detailledInfos)) {
+      const index = Array(detailledInfo.sum.length).fill(0);
+      for (let d = 0; d < detailledInfo.sum.length; d++) {
+        index[d] = detailledInfo.sum[d] / detailledInfo.count;
+      }
+
+      labelsInfo[label] = {
+        id: detailledInfo.id,
+        centroidIndex: index,
+        count: detailledInfo.count,
+        height: (detailledInfo.maxZ - detailledInfo.minZ + 1) * spacing[2]
+      };
+    }
 
     return labelsInfo;
   }
 
-  #convertToXYUnits(sliceOffset, unitVectors) {
+  /**
+   * Convert a slice local offset value to a slice local world coordinate.
+   *
+   * @param {number} sliceOffset Offset relative to the offset at the
+   * start of the slice.
+   * @param {number []} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number []} spacing The pixel spacing of the image.
+   *
+   * @returns {object} Point on the slice, scaled.
+   *  (object with the structure {x, y}).
+   */
+  #sliceOffsetToSliceWorld(sliceOffset, unitVectors, spacing) {
     let x = 0;
     let y = 0;
     if (unitVectors[0] > unitVectors[1]) {
@@ -341,23 +364,58 @@ export class LabelingFilter {
       y = Math.floor(sliceOffset / unitVectors[1]);
     }
 
-    return {x,y};
+    x = x * spacing[0];
+    y = y * spacing[1];
+
+    return {x, y};
   }
 
+  /**
+   * Calculated the length of a 2D line segment.
+   * Points should be in slice world space.
+   *
+   * @param {object} p1 The first endpoint of the line segment.
+   *  (object with the structure {x, y}).
+   * @param {object} p2 The second endpoint of the line segment.
+   *
+   * @returns {number} Length of the line segment relative to the X axis.
+   */
   #calculateDistance(p1, p2) {
     const xD = Math.abs(p1.x - p2.x);
     const yD = Math.abs(p1.y - p2.y);
     return Math.sqrt((xD * xD) + (yD * yD));
   }
 
+  /**
+   * Calculated the angle of a 2D line segment.
+   * Points should be in slice world space.
+   *
+   * @param {object} p1 The first endpoint of the line segment.
+   *  (object with the structure {x, y}).
+   * @param {object} p2 The second endpoint of the line segment.
+   *
+   * @returns {number} Angle of the line segment relative to the X axis.
+   */
   #calculateAngle(p1, p2) {
-    return Math.atan((p2.y - p1.y)/(p2.x - p1.x));
+    return Math.atan((p2.y - p1.y) / (p2.x - p1.x));
   }
 
+  /**
+   * Calculate the major and minor (perpendicular) diameters of each segment.
+   *
+   * @param {TypedArray} buffer The image buffer to calculate diameters for.
+   * @param {number[]} unitVectors The unit vectors for index to offset
+   *  conversion.
+   * @param {number[]} sizes The image dimensions.
+   * @param {number[]} spacing The pixel spacing of the image.
+   *
+   * @returns {object} The dictionary of calculated diameters.
+   */
   #calculateDiameters(
     buffer,
     unitVectors,
     sizes,
+    spacing
   ) {
     const maxDiameters = {};
 
@@ -365,8 +423,9 @@ export class LabelingFilter {
     for (let z = 0; z < sizes[2]; z++) {
       const zOffset = unitVectors[2] * z;
 
-      // TODO: It would be more efficient to calculate the convex hull, use rotating calipers
-      // to get antipodal points, and then calculate the major diameter from those.
+      // TODO: It would be more efficient to calculate the convex hull, use
+      // rotating calipers to get antipodal points, and then calculate the
+      // major diameter from those.
       // For now the naive way is fast enough for an initial implementation.
 
       let borderOffset1 = 0;
@@ -374,33 +433,42 @@ export class LabelingFilter {
         const offset1 = this.#borders[zOffset + borderOffset1];
         const label1 = this.#find(this.#labels[offset1]);
         const sliceOffset1 = offset1 - zOffset;
-        const slicePosition1 = this.#convertToXYUnits(sliceOffset1, unitVectors);
+        const slicePosition1 =
+          this.#sliceOffsetToSliceWorld(sliceOffset1, unitVectors, spacing);
 
         let borderOffset2 = 0;
         while (this.#borders[zOffset + borderOffset2] > 0) {
           const offset2 = this.#borders[zOffset + borderOffset2];
-          if(offset1 != offset2){
+          if (offset1 !== offset2) {
             const label2 = this.#find(this.#labels[offset2]);
 
             if (label1 === label2) {
               const sliceOffset2 = offset2 - zOffset;
-              const slicePosition2 = this.#convertToXYUnits(sliceOffset2, unitVectors);
+              const slicePosition2 =
+                this.#sliceOffsetToSliceWorld(
+                  sliceOffset2,
+                  unitVectors,
+                  spacing
+                );
 
-              const distance = this.#calculateDistance(slicePosition1, slicePosition2);
+              const distance =
+                this.#calculateDistance(slicePosition1, slicePosition2);
 
               const maxDiameter = maxDiameters[label1];
               if (
                 typeof maxDiameter === 'undefined' ||
-                maxDiameter.diameter < distance
+                maxDiameter.major.diameter < distance
               ) {
                 maxDiameters[label1] = {
                   id: buffer[offset1],
-                  diameter: distance,
-                  point1: slicePosition1,
-                  point2: slicePosition2,
-                  offset1: offset1,
-                  offset2: offset2,
-                  z: z
+                  major: {
+                    diameter: distance,
+                    point1: slicePosition1,
+                    point2: slicePosition2,
+                    offset1: offset1,
+                    offset2: offset2,
+                  },
+                  zIndex: z
                 };
               }
             }
@@ -409,18 +477,20 @@ export class LabelingFilter {
           borderOffset2++;
         }
 
-        borderOffset1 ++;
+        borderOffset1++;
       }
     }
 
     // Get the minor (perpendicular) diameter
     for (const [label, diameter] of Object.entries(maxDiameters)) {
-      const zOffset = unitVectors[2] * diameter.z;
-      const diameterAngle = this.#calculateAngle(diameter.point1, diameter.point2);
+      const zOffset = unitVectors[2] * diameter.zIndex;
+      const diameterAngle =
+        this.#calculateAngle(diameter.major.point1, diameter.major.point2);
 
-      // TODO: This could also be made faster by using a modified antipodal point algorithm
-      // that uses perpedicularity to the initial diameter instead of parallel tangents (we
-      // can't use the convex hull for this one, so the normal algorithm doesn't work)
+      // TODO: This could also be made faster by using a modified antipodal
+      // point algorithm that uses perpedicularity to the initial diameter
+      // instead of parallel tangents (we can't use the convex hull for this
+      // one, so the normal algorithm doesn't work).
       // For now the naive way is fast enough for an initial implementation.
 
       let borderOffset1 = 0;
@@ -428,37 +498,52 @@ export class LabelingFilter {
         const offset1 = this.#borders[zOffset + borderOffset1];
         const label1 = this.#find(this.#labels[offset1]);
 
-        if (label1 != label){
-          borderOffset1 ++;
+        if (label1.toString() !== label) {
+          borderOffset1++;
           continue;
         }
 
         const sliceOffset1 = offset1 - zOffset;
-        const slicePosition1 = this.#convertToXYUnits(sliceOffset1, unitVectors);
+        const slicePosition1 =
+          this.#sliceOffsetToSliceWorld(sliceOffset1, unitVectors, spacing);
 
         let borderOffset2 = 0;
         while (this.#borders[zOffset + borderOffset2] > 0) {
           const offset2 = this.#borders[zOffset + borderOffset2];
-          if(offset1 != offset2){
+          if (offset1 !== offset2) {
             const label2 = this.#find(this.#labels[offset2]);
-            if (label2 == label && label1 === label2) {
+            if (label2.toString() === label && label1 === label2) {
               const sliceOffset2 = offset2 - zOffset;
-              const slicePosition2 = this.#convertToXYUnits(sliceOffset2, unitVectors);
+              const slicePosition2 =
+                this.#sliceOffsetToSliceWorld(
+                  sliceOffset2,
+                  unitVectors,
+                  spacing
+                );
 
               // Check angle for perpendicularity
-              const angle = this.#calculateAngle(slicePosition1, slicePosition2);
+              const angle =
+                this.#calculateAngle(slicePosition1, slicePosition2);
 
               const angleDifference = Math.abs(angle - diameterAngle);
-              if ( angleDifference > (Math.PI/2) - 0.1 && Math.abs(angle - diameterAngle) < (Math.PI/2) + 0.1) {
-                const distance = this.#calculateDistance(slicePosition1, slicePosition2);
+              if (
+                angleDifference > (Math.PI / 2) - 0.1 &&
+                Math.abs(angle - diameterAngle) < (Math.PI / 2) + 0.1
+              ) {
+                const distance =
+                  this.#calculateDistance(slicePosition1, slicePosition2);
 
                 if (
-                  typeof diameter.perpDiameter === 'undefined' ||
-                  diameter.perpDiameter < distance
+                  typeof diameter.minor === 'undefined' ||
+                  diameter.minor.diameter < distance
                 ) {
-                  diameter.perpDiameter = distance;
-                  diameter.perpPoint1 = slicePosition1;
-                  diameter.perpPoint2 = slicePosition2;
+                  diameter.minor = {
+                    diameter: distance,
+                    point1: slicePosition1,
+                    point2: slicePosition2,
+                    offset1: offset1,
+                    offset2: offset2
+                  };
                 }
               }
             }
@@ -467,72 +552,11 @@ export class LabelingFilter {
           borderOffset2++;
         }
 
-        borderOffset1 ++;
-      } 
-    }
-
-    return Object.values(maxDiameters);
-  }
-
-  // TEMP
-  #plotPoints(imageBuffer, unitVectors, p0, p1, z) {
-    const plotLineLow = function(x0, y0, x1, y1, z) {
-      let dx = x1 - x0;
-      let dy = (y0 < y1) ? y1 - y0 : y0 - y1;
-      let D = 2*dy - dx;
-      let y = y0;
-      const yi = (y0 < y1) ? 1 : -1;
-
-      for (let x = x0; x <= x1; x++) {
-        const offset = 
-          (unitVectors[0] * x) +
-          (unitVectors[1] * y) +
-          (unitVectors[2] * z);
-        imageBuffer[offset] = imageBuffer[offset] + 128;
-
-        if (D>0) {
-          y = y + yi;
-          D = D - 2*dx;
-        }
-        D = D + 2*dy;
+        borderOffset1++;
       }
     }
 
-    const plotLineHigh = function(x0, y0, x1, y1, z) {
-      let dx = (x0 < x1) ? x1 - x0 : x0 - x1;
-      let dy = y1 - y0;
-      let D = 2*dx - dy;
-      let x = x0;
-      const xi = (x0 < x1) ? 1 : -1;
-
-      for (let y = y0; y <= y1; y++) {
-        const offset = 
-          (unitVectors[0] * x) +
-          (unitVectors[1] * y) +
-          (unitVectors[2] * z);
-        imageBuffer[offset] = imageBuffer[offset] + 128;
-
-        if (D>0) {
-          x = x + xi;
-          D = D - 2*dy;
-        }
-        D = D + 2*dx;
-      }
-    }
-
-    if (Math.abs(p1.y - p0.y) < Math.abs(p1.x - p0.x)) {
-      if (p0.x < p1.x) {
-        plotLineLow(p0.x, p0.y, p1.x, p1.y, z);
-      } else {
-        plotLineLow(p1.x, p1.y, p0.x, p0.y, z);
-      }
-    } else {
-      if (p0.y < p1.y) {
-        plotLineHigh(p0.x, p0.y, p1.x, p1.y, z);
-      } else {
-        plotLineHigh(p1.x, p1.y, p0.x, p0.y, z);
-      }
-    }
+    return maxDiameters;
   }
 
   /**
@@ -545,13 +569,16 @@ export class LabelingFilter {
     const imageBuffer = data.imageBuffer;
     const unitVectors = data.unitVectors;
     const sizes = data.sizes;
+    const spacing = data.spacing;
     const totalSize = data.totalSize;
 
-    //TEMP
-    for (let i = 0; i < imageBuffer.length; i++) {
-      if (imageBuffer[i] >= 128)
-        imageBuffer[i] = imageBuffer[i] - 128;
+    // This is temporary until a proper method of displaying them is implmented
+    // ------
+    const debug = new LabelingDebug();
+    if (DIAMETER_DEBUG) {
+      debug.cleanBuffer(imageBuffer);
     }
+    // ------
 
     // generate labels
     this.#regenerateLabels(
@@ -565,6 +592,7 @@ export class LabelingFilter {
     const labelsInfo = this.#quantifyLabels(
       imageBuffer,
       unitVectors,
+      spacing
     );
 
     // calculate diameters
@@ -572,42 +600,35 @@ export class LabelingFilter {
       imageBuffer,
       unitVectors,
       sizes,
-    )
+      spacing
+    );
 
-    //TEMP
-    console.log(">>>> POKE Diameter", maxDiameters[0]);
-    console.log(">>>> POKE Unit vectors", unitVectors);
-    for (let z = 0; z < sizes[2]; z++) {
-      let borderOffset = 0;
-      console.log(">>>> POKE border1", this.#borders[(unitVectors[2] * z)]);
-      while (this.#borders[(unitVectors[2] * z) + borderOffset] > 0) {
-        const offset = this.#borders[(unitVectors[2] * z) + borderOffset];
-        if (imageBuffer[offset] > 0) {
-          imageBuffer[offset] = imageBuffer[offset] + 128;
+    // This is temporary until a proper method of displaying them is implmented
+    // ------
+    if (DIAMETER_DEBUG) {
+      debug.drawDebugLines(
+        imageBuffer,
+        unitVectors,
+        sizes,
+        spacing,
+        this.#borders,
+        maxDiameters
+      );
+    }
+    // ------
+
+    // merge calculations
+    const mergedLabelsInfo =
+      Object.entries(labelsInfo).map(
+        ([label, labelInfo]) => {
+          if (typeof maxDiameters[label] !== 'undefined') {
+            labelInfo.diameters = maxDiameters[label];
+          }
+
+          return labelInfo;
         }
-        borderOffset++;
-      }
-    }
-    for (let d = 0; d < maxDiameters.length; d++) {
-      this.#plotPoints(
-        imageBuffer, 
-        unitVectors, 
-        maxDiameters[d].point1,
-        maxDiameters[d].point2,
-        maxDiameters[d].z
       );
 
-      if (typeof maxDiameters[d].perpDiameter !== "undefined") {
-        this.#plotPoints(
-        imageBuffer, 
-        unitVectors, 
-        maxDiameters[d].perpPoint1,
-        maxDiameters[d].perpPoint2,
-        maxDiameters[d].z
-      );
-      }
-    }
-
-    return labelsInfo;
+    return mergedLabelsInfo;
   }
 } // class labelingFilter

--- a/src/image/labelingFilter.js
+++ b/src/image/labelingFilter.js
@@ -1,4 +1,6 @@
 import {LabelingDebug} from './labelingDebug.js';
+import {Point2D} from '../math/point.js';
+import {Line} from '../math/line.js';
 
 // Set this to true to show the debug contour and diameter display
 const DIAMETER_DEBUG = false;
@@ -380,8 +382,7 @@ export class LabelingFilter {
    *  conversion.
    * @param {number []} spacing The pixel spacing of the image.
    *
-   * @returns {object} Point on the slice, scaled.
-   *  (object with the structure {x, y}).
+   * @returns {Point2D} Point on the slice, scaled.
    */
   #sliceOffsetToSliceWorld(sliceOffset, unitVectors, spacing) {
     let x = 0;
@@ -397,37 +398,7 @@ export class LabelingFilter {
     x = x * spacing[0];
     y = y * spacing[1];
 
-    return {x, y};
-  }
-
-  /**
-   * Calculated the length of a 2D line segment.
-   * Points should be in slice world space.
-   *
-   * @param {object} p1 The first endpoint of the line segment.
-   *  (object with the structure {x, y}).
-   * @param {object} p2 The second endpoint of the line segment.
-   *
-   * @returns {number} Length of the line segment relative to the X axis.
-   */
-  #calculateDistance(p1, p2) {
-    const xD = Math.abs(p1.x - p2.x);
-    const yD = Math.abs(p1.y - p2.y);
-    return Math.sqrt((xD * xD) + (yD * yD));
-  }
-
-  /**
-   * Calculated the angle of a 2D line segment.
-   * Points should be in slice world space.
-   *
-   * @param {object} p1 The first endpoint of the line segment.
-   *  (object with the structure {x, y}).
-   * @param {object} p2 The second endpoint of the line segment.
-   *
-   * @returns {number} Angle of the line segment relative to the X axis.
-   */
-  #calculateAngle(p1, p2) {
-    return Math.atan((p2.y - p1.y) / (p2.x - p1.x));
+    return new Point2D(x, y);
   }
 
   /**
@@ -490,8 +461,8 @@ export class LabelingFilter {
                     spacing
                   );
 
-                const distance =
-                  this.#calculateDistance(slicePosition1, slicePosition2);
+                const sliceLine = new Line(slicePosition1, slicePosition2);
+                const distance = sliceLine.getLength();
 
                 const maxDiameter = maxDiameters[label1];
                 if (
@@ -502,8 +473,7 @@ export class LabelingFilter {
                     id: buffer[offset1],
                     major: {
                       diameter: distance,
-                      point1: slicePosition1,
-                      point2: slicePosition2,
+                      line: sliceLine,
                       offset1: offset1,
                       offset2: offset2,
                     },
@@ -524,8 +494,8 @@ export class LabelingFilter {
     // Get the minor (perpendicular) diameter
     for (const [label, diameter] of Object.entries(maxDiameters)) {
       const zOffset = unitVectors[2] * diameter.zIndex;
-      const diameterAngle =
-        this.#calculateAngle(diameter.major.point1, diameter.major.point2);
+      const diameterLine = diameter.major.line;
+      const diameterAngle = diameterLine.getInclination();
 
       // TODO: This could also be made faster by using a modified antipodal
       // point algorithm that uses perpedicularity to the initial diameter
@@ -562,16 +532,15 @@ export class LabelingFilter {
                 );
 
               // Check angle for perpendicularity
-              const angle =
-                this.#calculateAngle(slicePosition1, slicePosition2);
+              const sliceLine = new Line(slicePosition1, slicePosition2);
+              const angle = sliceLine.getInclination();
 
               const angleDifference = Math.abs(angle - diameterAngle);
               if (
-                angleDifference > (Math.PI / 2) - 0.1 &&
-                Math.abs(angle - diameterAngle) < (Math.PI / 2) + 0.1
+                angleDifference > 89.5 &&
+                angleDifference < 90.5
               ) {
-                const distance =
-                  this.#calculateDistance(slicePosition1, slicePosition2);
+                const distance = sliceLine.getLength();
 
                 if (
                   typeof diameter.minor === 'undefined' ||
@@ -579,8 +548,7 @@ export class LabelingFilter {
                 ) {
                   diameter.minor = {
                     diameter: distance,
-                    point1: slicePosition1,
-                    point2: slicePosition2,
+                    line: sliceLine,
                     offset1: offset1,
                     offset2: offset2
                   };
@@ -612,7 +580,8 @@ export class LabelingFilter {
     const spacing = data.spacing;
     const totalSize = data.totalSize;
 
-    // This is temporary until a proper method of displaying them is implmented
+    //TODO: This is temporary until a proper method of displaying
+    // them is implmented.
     // ------
     const debug = new LabelingDebug();
     if (DIAMETER_DEBUG) {
@@ -644,7 +613,8 @@ export class LabelingFilter {
       labelsInfo
     );
 
-    // This is temporary until a proper method of displaying them is implmented
+    //TODO: This is temporary until a proper method of displaying
+    // them is implmented.
     // ------
     if (DIAMETER_DEBUG) {
       debug.drawDebugLines(
@@ -663,13 +633,35 @@ export class LabelingFilter {
       Object.entries(labelsInfo).map(
         ([label, labelInfo]) => {
           if (typeof maxDiameters[label] !== 'undefined') {
-            labelInfo.diameters = maxDiameters[label];
+            const diameters = maxDiameters[label];
+
+            // Duplicate information
+            delete diameters.id;
+            delete diameters.zIndex;
+
+            // These are in weird units and aren't helpful to pass back
+            delete diameters.major.line;
+            delete diameters.minor.line;
+
+            labelInfo.diameters = diameters;
           }
 
           return labelInfo;
         }
       );
 
-    return mergedLabelsInfo;
+    const returnEvent = {
+      labels: mergedLabelsInfo,
+    };
+
+    //TODO: This is temporary until a proper method of displaying
+    // them is implmented.
+    // ------
+    if (DIAMETER_DEBUG) {
+      returnEvent.buffer = imageBuffer;
+    }
+    // ------
+
+    return returnEvent;
   }
 } // class labelingFilter

--- a/src/image/labelingFilter.js
+++ b/src/image/labelingFilter.js
@@ -33,6 +33,13 @@ export class LabelingFilter {
   #labels;
 
   /**
+   * A buffer containing a list of border pixels for each layer.
+   *
+   * @type {Int32Array}
+   */
+  #borders;
+
+  /**
    * Union-find find operation.
    * Ref: {@link https://en.wikipedia.org/wiki/Disjoint-set_data_structure}.
    *
@@ -96,12 +103,16 @@ export class LabelingFilter {
       // on large images.
       this.#unionFind = new Int32Array(totalSize);
       this.#labels = new Int32Array(totalSize);
+      this.#borders = new Int32Array(totalSize);
     }
 
     // Generate the Hoshen–Kopelman labels
-    for (let x = 0; x < sizes[0]; x++) {
-      for (let y = 0; y < sizes[1]; y++) {
-        for (let z = 0; z < sizes[2]; z++) {
+    for (let z = 0; z < sizes[2]; z++) {
+
+      let borderOffset = 0;
+
+      for (let x = 0; x < sizes[0]; x++) {
+        for (let y = 0; y < sizes[1]; y++) {
 
           const thisOffset =
             (unitVectors[0] * x) +
@@ -120,6 +131,9 @@ export class LabelingFilter {
             const yOffset = thisOffset - unitVectors[1];
             const zOffset = thisOffset - unitVectors[2];
 
+            const xOffsetp = thisOffset + unitVectors[0];
+            const yOffsetp = thisOffset + unitVectors[1];
+
             // Neighbor values
             let xValue = 0;
             if (x > 0) {
@@ -132,6 +146,15 @@ export class LabelingFilter {
             let zValue = 0;
             if (z > 0) {
               zValue = buffer[zOffset];
+            };
+
+            let xValuep = 0;
+            if (x < sizes[0] - 1) {
+              xValuep = buffer[xOffsetp];
+            };
+            let yValuep = 0;
+            if (y < sizes[1] - 1) {
+              yValuep = buffer[yOffsetp];
             };
 
             // Neighbor labels
@@ -209,9 +232,23 @@ export class LabelingFilter {
               this.#union(xLabel, zLabel);
               this.#labels[thisOffset] = this.#find(xLabel);
             }
+
+            // Border check
+            if (
+              xValue != thisValue || 
+              yValue != thisValue ||
+              xValuep != thisValue || 
+              yValuep != thisValue 
+            ) {
+              this.#borders[(unitVectors[2] * z) + borderOffset] = thisOffset;
+              borderOffset++;
+            }
           }
         }
       }
+
+      this.#borders[(unitVectors[2] * z) + borderOffset] = 0;
+
     }
   }
 
@@ -293,6 +330,211 @@ export class LabelingFilter {
     return labelsInfo;
   }
 
+  #convertToXYUnits(sliceOffset, unitVectors) {
+    let x = 0;
+    let y = 0;
+    if (unitVectors[0] > unitVectors[1]) {
+      y = (sliceOffset % unitVectors[0]) / unitVectors[1];
+      x = Math.floor(sliceOffset / unitVectors[0]);
+    } else {
+      x = (sliceOffset % unitVectors[1]) / unitVectors[0];
+      y = Math.floor(sliceOffset / unitVectors[1]);
+    }
+
+    return {x,y};
+  }
+
+  #calculateDistance(p1, p2) {
+    const xD = Math.abs(p1.x - p2.x);
+    const yD = Math.abs(p1.y - p2.y);
+    return Math.sqrt((xD * xD) + (yD * yD));
+  }
+
+  #calculateAngle(p1, p2) {
+    return Math.atan((p2.y - p1.y)/(p2.x - p1.x));
+  }
+
+  #calculateDiameters(
+    buffer,
+    unitVectors,
+    sizes,
+  ) {
+    const maxDiameters = {};
+
+    // Get the major diameter
+    for (let z = 0; z < sizes[2]; z++) {
+      const zOffset = unitVectors[2] * z;
+
+      // TODO: It would be more efficient to calculate the convex hull, use rotating calipers
+      // to get antipodal points, and then calculate the major diameter from those.
+      // For now the naive way is fast enough for an initial implementation.
+
+      let borderOffset1 = 0;
+      while (this.#borders[zOffset + borderOffset1] > 0) {
+        const offset1 = this.#borders[zOffset + borderOffset1];
+        const label1 = this.#find(this.#labels[offset1]);
+        const sliceOffset1 = offset1 - zOffset;
+        const slicePosition1 = this.#convertToXYUnits(sliceOffset1, unitVectors);
+
+        let borderOffset2 = 0;
+        while (this.#borders[zOffset + borderOffset2] > 0) {
+          const offset2 = this.#borders[zOffset + borderOffset2];
+          if(offset1 != offset2){
+            const label2 = this.#find(this.#labels[offset2]);
+
+            if (label1 === label2) {
+              const sliceOffset2 = offset2 - zOffset;
+              const slicePosition2 = this.#convertToXYUnits(sliceOffset2, unitVectors);
+
+              const distance = this.#calculateDistance(slicePosition1, slicePosition2);
+
+              const maxDiameter = maxDiameters[label1];
+              if (
+                typeof maxDiameter === 'undefined' ||
+                maxDiameter.diameter < distance
+              ) {
+                maxDiameters[label1] = {
+                  id: buffer[offset1],
+                  diameter: distance,
+                  point1: slicePosition1,
+                  point2: slicePosition2,
+                  offset1: offset1,
+                  offset2: offset2,
+                  z: z
+                };
+              }
+            }
+          }
+
+          borderOffset2++;
+        }
+
+        borderOffset1 ++;
+      }
+    }
+
+    // Get the minor (perpendicular) diameter
+    for (const [label, diameter] of Object.entries(maxDiameters)) {
+      const zOffset = unitVectors[2] * diameter.z;
+      const diameterAngle = this.#calculateAngle(diameter.point1, diameter.point2);
+
+      // TODO: This could also be made faster by using a modified antipodal point algorithm
+      // that uses perpedicularity to the initial diameter instead of parallel tangents (we
+      // can't use the convex hull for this one, so the normal algorithm doesn't work)
+      // For now the naive way is fast enough for an initial implementation.
+
+      let borderOffset1 = 0;
+      while (this.#borders[zOffset + borderOffset1] > 0) {
+        const offset1 = this.#borders[zOffset + borderOffset1];
+        const label1 = this.#find(this.#labels[offset1]);
+
+        if (label1 != label){
+          borderOffset1 ++;
+          continue;
+        }
+
+        const sliceOffset1 = offset1 - zOffset;
+        const slicePosition1 = this.#convertToXYUnits(sliceOffset1, unitVectors);
+
+        let borderOffset2 = 0;
+        while (this.#borders[zOffset + borderOffset2] > 0) {
+          const offset2 = this.#borders[zOffset + borderOffset2];
+          if(offset1 != offset2){
+            const label2 = this.#find(this.#labels[offset2]);
+            if (label2 == label && label1 === label2) {
+              const sliceOffset2 = offset2 - zOffset;
+              const slicePosition2 = this.#convertToXYUnits(sliceOffset2, unitVectors);
+
+              // Check angle for perpendicularity
+              const angle = this.#calculateAngle(slicePosition1, slicePosition2);
+
+              const angleDifference = Math.abs(angle - diameterAngle);
+              if ( angleDifference > (Math.PI/2) - 0.1 && Math.abs(angle - diameterAngle) < (Math.PI/2) + 0.1) {
+                const distance = this.#calculateDistance(slicePosition1, slicePosition2);
+
+                if (
+                  typeof diameter.perpDiameter === 'undefined' ||
+                  diameter.perpDiameter < distance
+                ) {
+                  diameter.perpDiameter = distance;
+                  diameter.perpPoint1 = slicePosition1;
+                  diameter.perpPoint2 = slicePosition2;
+                }
+              }
+            }
+          }
+
+          borderOffset2++;
+        }
+
+        borderOffset1 ++;
+      } 
+    }
+
+    return Object.values(maxDiameters);
+  }
+
+  // TEMP
+  #plotPoints(imageBuffer, unitVectors, p0, p1, z) {
+    const plotLineLow = function(x0, y0, x1, y1, z) {
+      let dx = x1 - x0;
+      let dy = (y0 < y1) ? y1 - y0 : y0 - y1;
+      let D = 2*dy - dx;
+      let y = y0;
+      const yi = (y0 < y1) ? 1 : -1;
+
+      for (let x = x0; x <= x1; x++) {
+        const offset = 
+          (unitVectors[0] * x) +
+          (unitVectors[1] * y) +
+          (unitVectors[2] * z);
+        imageBuffer[offset] = imageBuffer[offset] + 128;
+
+        if (D>0) {
+          y = y + yi;
+          D = D - 2*dx;
+        }
+        D = D + 2*dy;
+      }
+    }
+
+    const plotLineHigh = function(x0, y0, x1, y1, z) {
+      let dx = (x0 < x1) ? x1 - x0 : x0 - x1;
+      let dy = y1 - y0;
+      let D = 2*dx - dy;
+      let x = x0;
+      const xi = (x0 < x1) ? 1 : -1;
+
+      for (let y = y0; y <= y1; y++) {
+        const offset = 
+          (unitVectors[0] * x) +
+          (unitVectors[1] * y) +
+          (unitVectors[2] * z);
+        imageBuffer[offset] = imageBuffer[offset] + 128;
+
+        if (D>0) {
+          x = x + xi;
+          D = D - 2*dy;
+        }
+        D = D + 2*dx;
+      }
+    }
+
+    if (Math.abs(p1.y - p0.y) < Math.abs(p1.x - p0.x)) {
+      if (p0.x < p1.x) {
+        plotLineLow(p0.x, p0.y, p1.x, p1.y, z);
+      } else {
+        plotLineLow(p1.x, p1.y, p0.x, p0.y, z);
+      }
+    } else {
+      if (p0.y < p1.y) {
+        plotLineHigh(p0.x, p0.y, p1.x, p1.y, z);
+      } else {
+        plotLineHigh(p1.x, p1.y, p0.x, p0.y, z);
+      }
+    }
+  }
+
   /**
    * Run the filter.
    *
@@ -304,6 +546,12 @@ export class LabelingFilter {
     const unitVectors = data.unitVectors;
     const sizes = data.sizes;
     const totalSize = data.totalSize;
+
+    //TEMP
+    for (let i = 0; i < imageBuffer.length; i++) {
+      if (imageBuffer[i] >= 128)
+        imageBuffer[i] = imageBuffer[i] - 128;
+    }
 
     // generate labels
     this.#regenerateLabels(
@@ -318,6 +566,47 @@ export class LabelingFilter {
       imageBuffer,
       unitVectors,
     );
+
+    // calculate diameters
+    const maxDiameters = this.#calculateDiameters(
+      imageBuffer,
+      unitVectors,
+      sizes,
+    )
+
+    //TEMP
+    console.log(">>>> POKE Diameter", maxDiameters[0]);
+    console.log(">>>> POKE Unit vectors", unitVectors);
+    for (let z = 0; z < sizes[2]; z++) {
+      let borderOffset = 0;
+      console.log(">>>> POKE border1", this.#borders[(unitVectors[2] * z)]);
+      while (this.#borders[(unitVectors[2] * z) + borderOffset] > 0) {
+        const offset = this.#borders[(unitVectors[2] * z) + borderOffset];
+        if (imageBuffer[offset] > 0) {
+          imageBuffer[offset] = imageBuffer[offset] + 128;
+        }
+        borderOffset++;
+      }
+    }
+    for (let d = 0; d < maxDiameters.length; d++) {
+      this.#plotPoints(
+        imageBuffer, 
+        unitVectors, 
+        maxDiameters[d].point1,
+        maxDiameters[d].point2,
+        maxDiameters[d].z
+      );
+
+      if (typeof maxDiameters[d].perpDiameter !== "undefined") {
+        this.#plotPoints(
+        imageBuffer, 
+        unitVectors, 
+        maxDiameters[d].perpPoint1,
+        maxDiameters[d].perpPoint2,
+        maxDiameters[d].z
+      );
+      }
+    }
 
     return labelsInfo;
   }

--- a/src/image/labelingThread.js
+++ b/src/image/labelingThread.js
@@ -2,7 +2,7 @@ import {ThreadPool, WorkerTask} from '../utils/thread.js';
 
 // doc imports
 /* eslint-disable no-unused-vars */
-import {Size} from './size.js';
+import {Geometry} from './geometry.js';
 /* eslint-enable no-unused-vars */
 
 /**

--- a/src/image/labelingThread.js
+++ b/src/image/labelingThread.js
@@ -108,7 +108,7 @@ export class LabelingThread {
    * this is meant to be overridden.
    *
    * @param {object} _event The work item event fired when a labeling
-   *   calculation is completed. Event.data should contain a 'lebels' item.
+   *   calculation is completed. Event.data should contain a 'labels' item.
    */
   ondone(_event) {}
 }

--- a/src/image/labelingThread.js
+++ b/src/image/labelingThread.js
@@ -19,11 +19,14 @@ import {Size} from './size.js';
  * Generate a worker message to send to the labeling worker.
  *
  * @param {TypedArray} imageBuffer The buffer to label.
- * @param {Size} imageSize The image size.
+ * @param {Geometry} imageGeometry The image geometry.
  *
  * @returns {object} The message to send to the worker.
  */
-export function generateWorkerMessage(imageBuffer, imageSize) {
+export function generateWorkerMessage(imageBuffer, imageGeometry) {
+  const imageSize = imageGeometry.getSize();
+  const imageSpacing = imageGeometry.getSpacing();
+
   // We can't pass these metadata objects directly, so we will just
   // pull out what we need and pass that.
   const ndims = imageSize.length();
@@ -45,6 +48,7 @@ export function generateWorkerMessage(imageBuffer, imageSize) {
     imageBuffer: imageBuffer,
     unitVectors: unitVectors,
     sizes: sizes,
+    spacing: imageSpacing.getValues(),
     totalSize: totalSize
   };
 }
@@ -87,15 +91,15 @@ export class LabelingThread {
    * Trigger a labels recalculation.
    *
    * @param {TypedArray} imageBuffer The buffer to label.
-   * @param {Size} size The image size.
+   * @param {Geometry} geometry The image geometry.
    */
-  run(imageBuffer, size) {
+  run(imageBuffer, geometry) {
     // We can't just pass in an Image or we would get a circular dependency
 
     this.#threadPool.onworkitem = this.ondone;
 
     const workerTask = new LabelingWorkerTask(
-      generateWorkerMessage(imageBuffer, size),
+      generateWorkerMessage(imageBuffer, geometry),
       {}
     );
 

--- a/src/math/line.js
+++ b/src/math/line.js
@@ -172,6 +172,15 @@ export class Line {
   }
 
   /**
+   * Get a new line with the start and end flipped.
+   *
+   * @returns {Line} The new flipped line.
+   */
+  getFlipped() {
+    return new Line(this.#end, this.#begin);
+  }
+
+  /**
    * Quantify a line according to view information.
    *
    * @param {ViewController} viewController The associated view controller.

--- a/tests/image/labeling.test.js
+++ b/tests/image/labeling.test.js
@@ -1,4 +1,7 @@
+import {Point3D} from '../../src/math/point.js';
 import {Size} from '../../src/image/size.js';
+import {Spacing} from '../../src/image/spacing.js';
+import {Geometry} from '../../src/image/geometry.js';
 import {LabelingFilter} from '../../src/image/labelingFilter.js';
 import {generateWorkerMessage} from '../../src/image/labelingThread.js';
 
@@ -17,8 +20,19 @@ QUnit.module('image');
 QUnit.test('LabelingFilter class', function (assert) {
   const labelingFilter = new LabelingFilter();
 
+  // Unused, only needed to construct the geometry
+  const imgOrigins = new Point3D(0,0,0);
+  const imgSpacing = new Spacing([1,1,1]);
+
   // Basic labels
   const imgSize0 = new Size([3, 3, 2]);
+  const imgGeometry0 = 
+    new Geometry(
+      imgOrigins,
+      imgSize0,
+      imgSpacing
+    );
+
   /* eslint-disable @stylistic/js/array-element-newline */
   const imgBuffer0 = new Uint8Array([
     0, 0, 0,
@@ -30,7 +44,7 @@ QUnit.test('LabelingFilter class', function (assert) {
   ]);
   /* eslint-enable @stylistic/js/array-element-newline */
 
-  const imgEvent0 = generateWorkerMessage(imgBuffer0, imgSize0);
+  const imgEvent0 = generateWorkerMessage(imgBuffer0, imgGeometry0);
   const labels0 = labelingFilter.run(imgEvent0);
 
   assert.notStrictEqual(
@@ -61,6 +75,12 @@ QUnit.test('LabelingFilter class', function (assert) {
 
   // Touching labels of different ids
   const imgSize1 = new Size([3, 3, 2]);
+  const imgGeometry1 = 
+    new Geometry(
+      imgOrigins,
+      imgSize1,
+      imgSpacing
+    );
   /* eslint-disable @stylistic/js/array-element-newline */
   const imgBuffer1 = new Uint8Array([
     2, 2, 2,
@@ -72,7 +92,7 @@ QUnit.test('LabelingFilter class', function (assert) {
   ]);
   /* eslint-enable @stylistic/js/array-element-newline */
 
-  const imgEvent1 = generateWorkerMessage(imgBuffer1, imgSize1);
+  const imgEvent1 = generateWorkerMessage(imgBuffer1, imgGeometry1);
   const labels1 = labelingFilter.run(imgEvent1);
 
   assert.notStrictEqual(

--- a/tests/image/labeling.test.js
+++ b/tests/image/labeling.test.js
@@ -45,7 +45,8 @@ QUnit.test('LabelingFilter class', function (assert) {
   /* eslint-enable @stylistic/js/array-element-newline */
 
   const imgEvent0 = generateWorkerMessage(imgBuffer0, imgGeometry0);
-  const labels0 = labelingFilter.run(imgEvent0);
+  const labelEvent0 = labelingFilter.run(imgEvent0);
+  const labels0 = labelEvent0.labels;
 
   assert.notStrictEqual(
     typeof labels0,
@@ -93,7 +94,8 @@ QUnit.test('LabelingFilter class', function (assert) {
   /* eslint-enable @stylistic/js/array-element-newline */
 
   const imgEvent1 = generateWorkerMessage(imgBuffer1, imgGeometry1);
-  const labels1 = labelingFilter.run(imgEvent1);
+  const labelEvent1 = labelingFilter.run(imgEvent1);
+  const labels1 = labelEvent1.labels;
 
   assert.notStrictEqual(
     typeof labels1,

--- a/tests/image/labeling.test.js
+++ b/tests/image/labeling.test.js
@@ -13,6 +13,18 @@ import {generateWorkerMessage} from '../../src/image/labelingThread.js';
 QUnit.module('image');
 
 /**
+ * Check if a number is within epsilon of another number.
+ *
+ * @param {number} A First number.
+ * @param {number} B Number to compare.
+ * @param {number} epsilon Max difference.
+ * @returns {boolean} Are A and B close?
+ */
+function closeTo(A, B, epsilon) {
+  return Math.abs(A - B) <= epsilon;
+}
+
+/**
  * Tests for {@link LabelingFilter}.
  *
  * @function module:tests/image~LabelingFilter-class
@@ -154,6 +166,114 @@ QUnit.test('LabelingFilter class', function (assert) {
     labels1[2].centroidIndex,
     [1.5, 1.5, 0.5],
     'Expected id #1 centroidIndex for multiple labels'
+  );
+
+
+  // Larger labels for diameter calculation
+  // (Diameters are weird on very small segments)
+  const imgSize2 = new Size([6, 6, 3]);
+  const imgGeometry2 =
+    new Geometry(
+      imgOrigins,
+      imgSize2,
+      imgSpacing
+    );
+  /* eslint-disable @stylistic/js/array-element-newline */
+  const imgBuffer2 = new Uint8Array([
+    0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0,
+    0, 0, 1, 1, 1, 0,
+    0, 0, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0, 0,
+    0, 1, 1, 1, 1, 0,
+    0, 1, 1, 1, 1, 0,
+    0, 0, 1, 1, 1, 0,
+    0, 0, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0, 0,
+    0, 1, 1, 1, 1, 0,
+    0, 1, 1, 1, 1, 0,
+    0, 0, 0, 1, 1, 0,
+    0, 0, 0, 1, 1, 0,
+    0, 0, 0, 0, 0, 0,
+  ]);
+  /* eslint-enable @stylistic/js/array-element-newline */
+
+  const imgEvent2 = generateWorkerMessage(imgBuffer2, imgGeometry2);
+  const labelEvent2 = labelingFilter.run(imgEvent2);
+  const labels2 = labelEvent2.labels;
+
+  assert.notStrictEqual(
+    typeof labels2,
+    'undefined',
+    'Expected labels returned for label diameters'
+  );
+  assert.equal(
+    labels2.length,
+    1,
+    'Expected number of labels for label diameters'
+  );
+  assert.equal(
+    labels2[0].id,
+    1,
+    'Expected id #1 for label diameters'
+  );
+  assert.equal(
+    labels2[0].count,
+    32,
+    'Expected id #1 count for label diameters'
+  );
+
+  assert.notStrictEqual(
+    typeof labels2[0].diameters.minor,
+    'undefined',
+    'Expected minor diameter returned for label diameters'
+  );
+
+  const major2 = labels2[0].diameters.major;
+  const minor2 = labels2[0].diameters.minor;
+
+  assert.true(
+    closeTo(major2.diameter, 4.2426, 0.0001),
+    'Expected major diameter value for label diameters'
+  );
+  assert.true(
+    closeTo(minor2.diameter, 2.8284, 0.0001),
+    'Expected minor diameter value for label diameters'
+  );
+  assert.equal(
+    labels2[0].height,
+    3,
+    'Expected height for label diameters'
+  );
+  assert.equal(
+    labels2[0].largestSliceZ,
+    1,
+    'Expected largest slice Z for label diameters'
+  );
+  assert.equal(
+    major2.offset1,
+    43,
+    'Expected major offset 1 for label diameters'
+  );
+  assert.equal(
+    major2.offset2,
+    64,
+    'Expected major offset 2 for label diameters'
+  );
+  assert.equal(
+    minor2.offset1,
+    56,
+    'Expected minor offset 1 for label diameters'
+  );
+  assert.equal(
+    minor2.offset2,
+    46,
+    'Expected minor offset 2 for label diameters'
   );
 
 });

--- a/tests/image/labeling.test.js
+++ b/tests/image/labeling.test.js
@@ -21,12 +21,12 @@ QUnit.test('LabelingFilter class', function (assert) {
   const labelingFilter = new LabelingFilter();
 
   // Unused, only needed to construct the geometry
-  const imgOrigins = new Point3D(0,0,0);
-  const imgSpacing = new Spacing([1,1,1]);
+  const imgOrigins = new Point3D(0, 0, 0);
+  const imgSpacing = new Spacing([1, 1, 1]);
 
   // Basic labels
   const imgSize0 = new Size([3, 3, 2]);
-  const imgGeometry0 = 
+  const imgGeometry0 =
     new Geometry(
       imgOrigins,
       imgSize0,
@@ -75,7 +75,7 @@ QUnit.test('LabelingFilter class', function (assert) {
 
   // Touching labels of different ids
   const imgSize1 = new Size([3, 3, 2]);
-  const imgGeometry1 = 
+  const imgGeometry1 =
     new Geometry(
       imgOrigins,
       imgSize1,

--- a/tests/pacs/viewer.ui.segment.js
+++ b/tests/pacs/viewer.ui.segment.js
@@ -24,7 +24,21 @@ import {
 // doc imports
 /* eslint-disable no-unused-vars */
 import {App} from '../../src/app/application.js';
+/**
+ * @typedef {import('../../src/image/image.js').Label} Label
+ */
 /* eslint-enable no-unused-vars */
+
+/**
+ * Segmentation type.
+ *
+ * @typedef Segmentation
+ * @property {number} dataId The segmentation data ID.
+ * @property {Label[]} labels The segmentation labels.
+ * @property {boolean} hasNewSegments If the segmentation is new.
+ * @property {object[]} segments The segmentation segments.
+ * @property {MaskSegmentViewHelper} viewHelper A view helper.
+ */
 
 // global vars
 const _colours = [
@@ -53,6 +67,7 @@ const _colours = [
 // colour array to pick from
 let _coloursPick = _colours.slice();
 // segmentation
+/** @type {Segmentation[]} */
 const _segmentations = [];
 
 /**
@@ -877,18 +892,18 @@ export class SegmentationUI {
         if (res !== start) {
           res += ', ';
         }
-        res += label.volume.toPrecision(4) + i18n.t(label.unit);
+        res += label.volume.value.toPrecision(4) + i18n.t(label.volume.unit);
         if (typeof label.diameters !== 'undefined') {
           res += ' (';
           res +=
-            label.diameters.major.diameter.toPrecision(4) +
-            i18n.t(label.diameterUnit);
+            label.diameters.major.diameter.value.toPrecision(4) +
+            i18n.t(label.diameters.major.diameter.unit);
           res += ', ';
           res +=
-            label.diameters.minor.diameter.toPrecision(4) +
-            i18n.t(label.diameterUnit);
+            label.diameters.minor.diameter.value.toPrecision(4) +
+            i18n.t(label.diameters.minor.diameter.unit);
           res += ', ';
-          res += label.height.toPrecision(4) + i18n.t(label.diameterUnit);
+          res += label.height.value.toPrecision(4) + i18n.t(label.height.unit);
           res += ')';
         }
       }

--- a/tests/pacs/viewer.ui.segment.js
+++ b/tests/pacs/viewer.ui.segment.js
@@ -878,6 +878,19 @@ export class SegmentationUI {
           res += ', ';
         }
         res += label.volume.toPrecision(4) + i18n.t(label.unit);
+        if (typeof label.diameters !== 'undefined') {
+          res += ' (';
+          res +=
+            label.diameters.major.diameter.toPrecision(4) +
+            i18n.t(label.diameterUnit);
+          res += ', ';
+          res +=
+            label.diameters.minor.diameter.toPrecision(4) +
+            i18n.t(label.diameterUnit);
+          res += ', ';
+          res += label.height.toPrecision(4) + i18n.t(label.diameterUnit);
+          res += ')';
+        }
       }
     }
     res += ']';


### PR DESCRIPTION
- Adds feature described in #2000

> Note: To view a debug display of the diameters being calculated, set `DIAMETER_DEBUG` in `src/image/labelingFilter.js` to `true`. This debug display is temporary and just meant to make development easier.