### PR TITLE
2010 Segmentation overlap

### DIFF
--- a/src/image/maskSegmentHelper.js
+++ b/src/image/maskSegmentHelper.js
@@ -175,12 +175,22 @@ export class MaskSegmentHelper {
   }
 
   /**
-   * An Dictionary containing the count of overlapping voxels of a single
-   * segment with a set of different segments.
-   * The key is the segment number of the overlapping segment in the set.
-   * The value is the overlapping voxel count.
+   * The overlap count of a signle segment with another segment.
    *
-   * @typedef {Object.<number, number>} OverlapCount
+   * @typedef OverlapCount
+   * @property {number} count The number of overlapping voxels.
+   * @property {number} percentage The overlap percentage between 0 and 1.
+   */
+
+  /**
+   * The count of overlapping voxels of a single segment with a set of
+   * different segments.
+   *
+   * @typedef Overlap
+   * @property {Object.<number, OverlapCount>} overlap A Dictionary
+   *  containing the counts. The key is the segment number of the overlapping
+   *  segment.
+   * @property {number} count The voxel volume of this segment.
    */
 
   /**
@@ -190,7 +200,7 @@ export class MaskSegmentHelper {
    * The value is a Dictionary of all of the segments in the second set
    * that overlap with the key segment.
    *
-   * @typedef {Object.<number, OverlapCount>} Overlap
+   * @typedef {Object.<number, Overlap>} OverlapMap
    */
 
   /**
@@ -198,7 +208,7 @@ export class MaskSegmentHelper {
    * It is assumed these images have the same orientation.
    *
    * @param {Image} compare The segmentation image to find overlap with.
-   * @returns {Overlap} The overlapping voxel counts. First level is the
+   * @returns {OverlapMap} The overlapping voxel counts. First level is the
    *  segments from this image, second level is the compare image segments.
    */
   findOverlap(compare) {
@@ -209,7 +219,7 @@ export class MaskSegmentHelper {
     const compareSize = compareGeometry.getSize();
 
     /**
-     * @type {Overlap}
+     * @type {OverlapMap}
      */
     const overlap = {};
 
@@ -217,6 +227,15 @@ export class MaskSegmentHelper {
     for (let i = 0; i < thisTotalSize; i++) {
       const thisValue = this.#mask.getValueAtOffset(i);
       if (thisValue !== 0) {
+        if (typeof overlap[thisValue] !== 'undefined') {
+          overlap[thisValue].count += 1;
+        } else {
+          overlap[thisValue] = {
+            overlap: {},
+            count: 1
+          };
+        }
+
         const thisIndex = thisSize.offsetToIndex(i);
         const thisWorld = thisGeometry.indexToWorld(thisIndex);
         const compareIndex = compareGeometry.worldToIndex(thisWorld);
@@ -224,17 +243,21 @@ export class MaskSegmentHelper {
         const compareValue = compare.getValueAtOffset(compareOffset);
 
         if (typeof compareValue !== 'undefined' && compareValue !== 0) {
-          if (typeof overlap[thisValue] !== 'undefined') {
-            if (typeof overlap[thisValue][compareValue] !== 'undefined') {
-              overlap[thisValue][compareValue] += 1;
-            } else {
-              overlap[thisValue][compareValue] = 1;
-            }
+          if (typeof overlap[thisValue].overlap[compareValue] !== 'undefined') {
+            overlap[thisValue].overlap[compareValue].count += 1;
           } else {
-            overlap[thisValue] = {};
-            overlap[thisValue][compareValue] = 1;
+            overlap[thisValue].overlap[compareValue] = {
+              count: 1,
+              percentage: 0
+            };
           }
         }
+      }
+    }
+
+    for (const thisOverlap of Object.values(overlap)) {
+      for (const overlapCount of Object.values(thisOverlap.overlap)) {
+        overlapCount.percentage = overlapCount.count / thisOverlap.count;
       }
     }
 

--- a/src/image/maskSegmentHelper.js
+++ b/src/image/maskSegmentHelper.js
@@ -174,4 +174,71 @@ export class MaskSegmentHelper {
     }
   }
 
+  /**
+   * An Dictionary containing the count of overlapping voxels of a single
+   * segment with a set of different segments.
+   * The key is the segment number of the overlapping segment in the set.
+   * The value is the overlapping voxel count.
+   *
+   * @typedef {Object.<number, number>} OverlapCount
+   */
+
+  /**
+   * An Dictionary containing the count of overlapping voxels between two
+   * sets of segments.
+   * The key is the segment number of a segment in the first set.
+   * The value is a Dictionary of all of the segments in the second set
+   * that overlap with the key segment.
+   *
+   * @typedef {Object.<number, OverlapCount>} Overlap
+   */
+
+  /**
+   * Find the overlap for each segment between two segmentation masks.
+   * It is assumed these images have the same orientation.
+   *
+   * @param {Image} compare The segmentation image to find overlap with.
+   * @returns {Overlap} The overlapping voxel counts. First level is the
+   *  segments from this image, second level is the compare image segments.
+   */
+  findOverlap(compare) {
+    // Find the overlapping slices
+    const thisGeometry = this.#mask.getGeometry();
+    const thisSize = thisGeometry.getSize();
+    const compareGeometry = compare.getGeometry();
+    const compareSize = compareGeometry.getSize();
+
+    /**
+     * @type {Overlap}
+     */
+    const overlap = {};
+
+    const thisTotalSize = thisSize.getTotalSize();
+    for (let i = 0; i < thisTotalSize; i++) {
+      const thisValue = this.#mask.getValueAtOffset(i);
+      if (thisValue !== 0) {
+        const thisIndex = thisSize.offsetToIndex(i);
+        const thisWorld = thisGeometry.indexToWorld(thisIndex);
+        const compareIndex = compareGeometry.worldToIndex(thisWorld);
+        const compareOffset = compareSize.indexToOffset(compareIndex);
+        const compareValue = compare.getValueAtOffset(compareOffset);
+
+        if (typeof compareValue !== 'undefined' && compareValue !== 0) {
+          if (typeof overlap[thisValue] !== 'undefined') {
+            if (typeof overlap[thisValue][compareValue] !== 'undefined') {
+              overlap[thisValue][compareValue] += 1;
+            } else {
+              overlap[thisValue][compareValue] = 1;
+            }
+          } else {
+            overlap[thisValue] = {};
+            overlap[thisValue][compareValue] = 1;
+          }
+        }
+      }
+    }
+
+    return overlap;
+  }
+
 } // class MaskSegmentHelper

--- a/tests/image/segment.test.js
+++ b/tests/image/segment.test.js
@@ -1,0 +1,161 @@
+import {Point3D} from '../../src/math/point.js';
+import {Size} from '../../src/image/size.js';
+import {Spacing} from '../../src/image/spacing.js';
+import {Matrix33} from '../../src/math/matrix.js';
+import {Geometry} from '../../src/image/geometry.js';
+import {MaskSegmentHelper} from '../../src/image/maskSegmentHelper.js';
+import {Image} from '../../src/image/image.js';
+
+/**
+ * Tests for the 'image/maskSegmentHelper.js' file.
+ */
+
+/* global QUnit */
+QUnit.module('image');
+
+/**
+ * Tests for {@link MaskSegmentHelper} findOverlap.
+ *
+ * @function module:tests/image~MaskSegmentHelper-findOverlap
+ */
+QUnit.test('MaskSegmentHelper findOverlap', function (assert) {
+  const imgOrigins = [new Point3D(0, 0, 0)];
+  const imgSpacing = new Spacing([1, 1, 1]);
+  const imgSize = new Size([4, 4, 2]);
+  /* eslint-disable @stylistic/js/array-element-newline */
+  const o = [
+    1, 0, 0,
+    0, 0, 1,
+    0, 1, 0,
+  ];
+  /* eslint-enable @stylistic/js/array-element-newline */
+  const imgOrientation = new Matrix33(o);
+  const imgGeometry =
+    new Geometry(
+      imgOrigins,
+      imgSize,
+      imgSpacing,
+      imgOrientation
+    );
+  /* eslint-disable @stylistic/js/array-element-newline */
+  const imgBuffer0 = new Uint8Array([
+    1, 1, 0, 0,
+    1, 1, 0, 0,
+    0, 0, 2, 2,
+    0, 0, 2, 2,
+
+    1, 1, 0, 0,
+    1, 1, 0, 0,
+    0, 0, 0, 3,
+    0, 0, 3, 3
+  ]);
+  /* eslint-enable @stylistic/js/array-element-newline */
+  const image0 = new Image(imgGeometry, imgBuffer0);
+
+  /* eslint-disable @stylistic/js/array-element-newline */
+  const imgBuffer1 = new Uint8Array([
+    2, 2, 3, 3,
+    2, 1, 1, 3,
+    4, 1, 1, 2,
+    4, 4, 2, 2,
+
+    2, 2, 3, 3,
+    2, 1, 1, 3,
+    4, 1, 1, 2,
+    4, 4, 2, 2
+  ]);
+  /* eslint-enable @stylistic/js/array-element-newline */
+  const image1 = new Image(imgGeometry, imgBuffer1);
+  image1.setMeta({});
+  const segmentHelper1 = new MaskSegmentHelper(image1);
+
+  const overlap1 = segmentHelper1.findOverlap(image0);
+
+  assert.notStrictEqual(
+    typeof overlap1,
+    'undefined',
+    'Expected overlaps returned for find overlap'
+  );
+
+  assert.notStrictEqual(
+    typeof overlap1[1],
+    'undefined',
+    'Expected overlaps on label 1 returned for find overlap'
+  );
+  assert.notStrictEqual(
+    typeof overlap1[2],
+    'undefined',
+    'Expected overlaps on label 2 returned for find overlap'
+  );
+  assert.strictEqual(
+    typeof overlap1[3],
+    'undefined',
+    'Expected no overlaps on label 3 returned for find overlap'
+  );
+  assert.strictEqual(
+    typeof overlap1[4],
+    'undefined',
+    'Expected no overlaps on label 4 returned for find overlap'
+  );
+
+  assert.notStrictEqual(
+    typeof overlap1[1][1],
+    'undefined',
+    'Expected overlaps on label 1 for label 1 returned for find overlap'
+  );
+  assert.notStrictEqual(
+    typeof overlap1[1][2],
+    'undefined',
+    'Expected overlaps on label 1 for label 2 returned for find overlap'
+  );
+  assert.strictEqual(
+    typeof overlap1[1][3],
+    'undefined',
+    'Expected no overlaps on label 1 for label 3 returned for find overlap'
+  );
+
+  assert.notStrictEqual(
+    typeof overlap1[2][1],
+    'undefined',
+    'Expected overlaps on label 2 for label 1 returned for find overlap'
+  );
+  assert.notStrictEqual(
+    typeof overlap1[2][2],
+    'undefined',
+    'Expected overlaps on label 2 for label 2 returned for find overlap'
+  );
+  assert.notStrictEqual(
+    typeof overlap1[2][3],
+    'undefined',
+    'Expected overlaps on label 2 for label 3 returned for find overlap'
+  );
+
+  assert.equal(
+    overlap1[1][1],
+    2,
+    'Expected count on label 1 for label 1 for find overlap'
+  );
+  assert.equal(
+    overlap1[1][2],
+    1,
+    'Expected count on label 1 for label 2 for find overlap'
+  );
+
+  assert.equal(
+    overlap1[2][1],
+    6,
+    'Expected count on label 2 for label 1 for find overlap'
+  );
+  assert.equal(
+    overlap1[2][2],
+    3,
+    'Expected count on label 2 for label 2 for find overlap'
+  );
+  assert.equal(
+    overlap1[2][2],
+    3,
+    'Expected count on label 2 for label 3 for find overlap'
+  );
+
+
+});

--- a/tests/image/segment.test.js
+++ b/tests/image/segment.test.js
@@ -71,6 +71,8 @@ QUnit.test('MaskSegmentHelper findOverlap', function (assert) {
 
   const overlap1 = segmentHelper1.findOverlap(image0);
 
+  // Undefined tests
+
   assert.notStrictEqual(
     typeof overlap1,
     'undefined',
@@ -87,75 +89,142 @@ QUnit.test('MaskSegmentHelper findOverlap', function (assert) {
     'undefined',
     'Expected overlaps on label 2 returned for find overlap'
   );
-  assert.strictEqual(
+  assert.notStrictEqual(
     typeof overlap1[3],
     'undefined',
-    'Expected no overlaps on label 3 returned for find overlap'
+    'Expected overlaps on label 3 returned for find overlap'
   );
-  assert.strictEqual(
+  assert.notStrictEqual(
     typeof overlap1[4],
     'undefined',
-    'Expected no overlaps on label 4 returned for find overlap'
+    'Expected overlaps on label 4 returned for find overlap'
   );
 
   assert.notStrictEqual(
-    typeof overlap1[1][1],
+    typeof overlap1[1].overlap[1],
     'undefined',
     'Expected overlaps on label 1 for label 1 returned for find overlap'
   );
   assert.notStrictEqual(
-    typeof overlap1[1][2],
+    typeof overlap1[1].overlap[2],
     'undefined',
     'Expected overlaps on label 1 for label 2 returned for find overlap'
   );
   assert.strictEqual(
-    typeof overlap1[1][3],
+    typeof overlap1[1].overlap[3],
     'undefined',
     'Expected no overlaps on label 1 for label 3 returned for find overlap'
   );
 
   assert.notStrictEqual(
-    typeof overlap1[2][1],
+    typeof overlap1[2].overlap[1],
     'undefined',
     'Expected overlaps on label 2 for label 1 returned for find overlap'
   );
   assert.notStrictEqual(
-    typeof overlap1[2][2],
+    typeof overlap1[2].overlap[2],
     'undefined',
     'Expected overlaps on label 2 for label 2 returned for find overlap'
   );
   assert.notStrictEqual(
-    typeof overlap1[2][3],
+    typeof overlap1[2].overlap[3],
     'undefined',
     'Expected overlaps on label 2 for label 3 returned for find overlap'
   );
 
   assert.equal(
-    overlap1[1][1],
+    Object.keys(overlap1[3].overlap).length,
+    0,
+    'Expected no overlaps on label 3 returned for find overlap'
+  );
+  assert.equal(
+    Object.keys(overlap1[4].overlap).length,
+    0,
+    'Expected no overlaps on label 4 returned for find overlap'
+  );
+
+  // Total count tests
+
+  assert.equal(
+    overlap1[1].count,
+    8,
+    'Expected count on label 1'
+  );
+
+  assert.equal(
+    overlap1[2].count,
+    12,
+    'Expected count on label 2'
+  );
+
+  assert.equal(
+    overlap1[3].count,
+    6,
+    'Expected count on label 3'
+  );
+
+  assert.equal(
+    overlap1[4].count,
+    6,
+    'Expected count on label 4'
+  );
+
+  // Overlap count tests
+
+  assert.equal(
+    overlap1[1].overlap[1].count,
     2,
     'Expected count on label 1 for label 1 for find overlap'
   );
   assert.equal(
-    overlap1[1][2],
+    overlap1[1].overlap[2].count,
     1,
     'Expected count on label 1 for label 2 for find overlap'
   );
 
   assert.equal(
-    overlap1[2][1],
+    overlap1[2].overlap[1].count,
     6,
     'Expected count on label 2 for label 1 for find overlap'
   );
   assert.equal(
-    overlap1[2][2],
+    overlap1[2].overlap[2].count,
     3,
     'Expected count on label 2 for label 2 for find overlap'
   );
   assert.equal(
-    overlap1[2][2],
+    overlap1[2].overlap[3].count,
     3,
     'Expected count on label 2 for label 3 for find overlap'
   );
 
+  // Overlap percentage tests
+
+  assert.equal(
+    overlap1[1].overlap[1].percentage,
+    0.25,
+    'Expected percentage on label 1 for label 1 for find overlap'
+  );
+  assert.equal(
+    overlap1[1].overlap[2].percentage,
+    0.125,
+    'Expected percentage on label 1 for label 2 for find overlap'
+  );
+
+  assert.equal(
+    overlap1[2].overlap[1].percentage,
+    0.5,
+    'Expected percentage on label 2 for label 1 for find overlap'
+  );
+  assert.equal(
+    overlap1[2].overlap[2].percentage,
+    0.25,
+    'Expected percentage on label 2 for label 2 for find overlap'
+  );
+  assert.equal(
+    overlap1[2].overlap[3].percentage,
+    0.25,
+    'Expected percentage on label 2 for label 3 for find overlap'
+  );
 
 });

--- a/tests/pacs/viewer.html
+++ b/tests/pacs/viewer.html
@@ -196,6 +196,13 @@ hr.vertical {
   border: 1px solid #fff;
   border-radius: 50%;
 }
+#overlap-checker {
+  margin-top: 2em;
+}
+#overlap-checker * {
+  margin-right: 0.5em;
+  width: auto;
+}
 </style>
 
 <!-- dwv build --><!--

--- a/tests/pacs/viewer.ui.segment.js
+++ b/tests/pacs/viewer.ui.segment.js
@@ -255,6 +255,30 @@ export class SegmentationUI {
   };
 
   /**
+   * Add to the list of segmentations on the overlap checker.
+   *
+   * @param {object} segmentation The segmentation to add.
+   * @param {number} segmentationIndex The segmentation index.
+   */
+  #addOverlapCheckerSelection(segmentation, segmentationIndex) {
+    const overlapSelect0 =
+      document.getElementById('overlap-checker-select-list-0');
+    const overlapSelect1 =
+      document.getElementById('overlap-checker-select-list-1');
+
+    const newOption0 = document.createElement('option');
+    newOption0.innerHTML = getSegmentationHtmlId(segmentationIndex);
+    newOption0.value = segmentation.dataId;
+
+    const newOption1 = document.createElement('option');
+    newOption1.innerHTML = getSegmentationHtmlId(segmentationIndex);
+    newOption1.value = segmentation.dataId;
+
+    overlapSelect0.appendChild(newOption0);
+    overlapSelect1.appendChild(newOption1);
+  }
+
+  /**
    * Add a segment HTML to the main HTML.
    *
    * @param {object} segmentation The segmentation.
@@ -273,6 +297,8 @@ export class SegmentationUI {
     const segList = document.getElementById('segmentation-list');
     segList.appendChild(item);
     segList.appendChild(addItem);
+
+    this.#addOverlapCheckerSelection(segmentation, _segmentations.length - 1);
   }
 
   /**
@@ -395,8 +421,9 @@ export class SegmentationUI {
       this.#addSegmentationHtml(segmentation);
     };
     addItem.appendChild(addSegmentationButton);
-
     segList.appendChild(addItem);
+
+    const overlapChecker = this.#getSegmentationOverlapHtml();
 
     // fieldset
     const legend = document.createElement('legend');
@@ -404,6 +431,7 @@ export class SegmentationUI {
     const fieldset = document.createElement('fieldset');
     fieldset.appendChild(legend);
     fieldset.appendChild(segList);
+    fieldset.appendChild(overlapChecker);
 
     // main div
     const line = document.createElement('div');
@@ -1027,4 +1055,91 @@ export class SegmentationUI {
     return segmentationItem;
   }
 
+  /**
+   * Get the HTML for the segmentation overlap chacker.
+   *
+   * @returns {HTMLLIElement} The HTML element.
+   */
+  #getSegmentationOverlapHtml() {
+    // create overlap checker
+    const overlapChecker = document.createElement('div');
+    overlapChecker.id = 'overlap-checker';
+
+    // label
+    const overlapLabel = document.createElement('label');
+    overlapLabel.innerHTML = 'Overlap:';
+    overlapChecker.appendChild(overlapLabel);
+
+    // dropdowns
+    const overlapSelect0 = document.createElement('select');
+    const overlapSelect1 = document.createElement('select');
+    overlapSelect0.id = 'overlap-checker-select-list-0';
+    overlapSelect1.id = 'overlap-checker-select-list-1';
+    overlapChecker.appendChild(overlapSelect0);
+    overlapChecker.appendChild(overlapSelect1);
+
+    // button
+    const overlapButton = document.createElement('button');
+    overlapButton.innerHTML = 'Check Overlap';
+    overlapChecker.appendChild(overlapButton);
+
+    // result holder
+    const overlapResult = document.createElement('div');
+    overlapChecker.appendChild(overlapResult);
+
+    overlapButton.onclick = (/*event*/) => {
+      const segment0 = overlapSelect0.value;
+      const segment1 = overlapSelect1.value;
+      const maskImage0 = this.#app.getData(segment0).image;
+      const maskImage1 = this.#app.getData(segment1).image;
+      const segHelper0 = new MaskSegmentHelper(maskImage0);
+      const segHelper1 = new MaskSegmentHelper(maskImage1);
+      const overlap = segHelper0.findOverlap(maskImage1);
+
+      overlapResult.innerHTML = ''; // clear old results
+      for (const [segmentNumber0, o] of Object.entries(overlap)) {
+        const segment0 = segHelper0.getSegment(Number(segmentNumber0));
+
+        // title (segment that these overlaps are for)
+        const segmentLabel = document.createElement('h4');
+        segmentLabel.innerHTML += segment0.label;
+        segmentLabel.innerHTML += ':\n';
+        overlapResult.appendChild(segmentLabel);
+
+        // create table
+        const overlapList = document.createElement('table');
+        const listHeaders = document.createElement('thead');
+
+        // table headers
+        const headerRow = document.createElement('tr');
+        const headerLabel = document.createElement('th');
+        headerLabel.innerHTML = 'Segmentation';
+        const headerValue = document.createElement('th');
+        headerValue.innerHTML = 'Overlap (voxels)';
+        headerRow.appendChild(headerLabel);
+        headerRow.appendChild(headerValue);
+        listHeaders.appendChild(headerRow);
+        overlapList.appendChild(listHeaders);
+
+        // table body
+        const listBody = document.createElement('tbody');
+        overlapList.appendChild(listBody);
+        for (const [segmentNumber1, count] of Object.entries(o)) {
+          const entry = document.createElement('tr');
+          const segment1 = segHelper1.getSegment(Number(segmentNumber1));
+          const entryLabel = document.createElement('td');
+          entryLabel.innerHTML += segment1.label;
+          const entryValue = document.createElement('td');
+          entryValue.innerHTML += count;
+          entry.appendChild(entryLabel);
+          entry.appendChild(entryValue);
+          listBody.appendChild(entry);
+        }
+
+        overlapResult.appendChild(overlapList);
+      }
+    };
+
+    return overlapChecker;
+  }
 }; // SegmentationUI

--- a/tests/pacs/viewer.ui.segment.js
+++ b/tests/pacs/viewer.ui.segment.js
@@ -1097,13 +1097,18 @@ export class SegmentationUI {
       const overlap = segHelper0.findOverlap(maskImage1);
 
       overlapResult.innerHTML = ''; // clear old results
-      for (const [segmentNumber0, o] of Object.entries(overlap)) {
+      for (
+        const [segmentNumber0, segmentOverlap] of
+        Object.entries(overlap)
+      ) {
         const segment0 = segHelper0.getSegment(Number(segmentNumber0));
 
         // title (segment that these overlaps are for)
         const segmentLabel = document.createElement('h4');
         segmentLabel.innerHTML += segment0.label;
-        segmentLabel.innerHTML += ':\n';
+        segmentLabel.innerHTML += ' (';
+        segmentLabel.innerHTML += segmentOverlap.count;
+        segmentLabel.innerHTML += ' voxels):';
         overlapResult.appendChild(segmentLabel);
 
         // create table
@@ -1116,23 +1121,33 @@ export class SegmentationUI {
         headerLabel.innerHTML = 'Segmentation';
         const headerValue = document.createElement('th');
         headerValue.innerHTML = 'Overlap (voxels)';
+        const headerPercentage = document.createElement('th');
+        headerPercentage.innerHTML = 'Overlap (percentage)';
         headerRow.appendChild(headerLabel);
         headerRow.appendChild(headerValue);
+        headerRow.appendChild(headerPercentage);
         listHeaders.appendChild(headerRow);
         overlapList.appendChild(listHeaders);
 
         // table body
         const listBody = document.createElement('tbody');
         overlapList.appendChild(listBody);
-        for (const [segmentNumber1, count] of Object.entries(o)) {
+        for (
+          const [segmentNumber1, count] of
+          Object.entries(segmentOverlap.overlap)
+        ) {
           const entry = document.createElement('tr');
           const segment1 = segHelper1.getSegment(Number(segmentNumber1));
           const entryLabel = document.createElement('td');
           entryLabel.innerHTML += segment1.label;
           const entryValue = document.createElement('td');
-          entryValue.innerHTML += count;
+          entryValue.innerHTML += count.count;
+          const entryPercentage = document.createElement('td');
+          entryPercentage.innerHTML += (count.percentage * 100).toPrecision(4);
+          entryPercentage.innerHTML += '%';
           entry.appendChild(entryLabel);
           entry.appendChild(entryValue);
+          entry.appendChild(entryPercentage);
           listBody.appendChild(entry);
         }
 


### PR DESCRIPTION
Addresses #2010 

- Add the ability to calculate the overlap between segments

> Note: The order that you pass the masks into the function matters, the function calculates the percentage based on the percent area of the first mask that the second mask is overlapping. The total voxel count is also only calculated for the segments of the first mask.