### PR TITLE
Fix multiple single frame loading error

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -1063,6 +1063,8 @@ export class Image extends EventTarget {
     // possible time
     const timeId = rhs.getGeometry().getInitialTime();
 
+    const totalSlices = this.#geometry.getCurrentTotalNumberOfSlices();
+
     // append frame if needed
     let isNewFrame = false;
     if (typeof timeId !== 'undefined' &&
@@ -1108,7 +1110,6 @@ export class Image extends EventTarget {
     }
     // offset of the input slice
     const indexOffset = fullSliceIndex * sliceSize;
-    const totalSlices = this.#geometry.getCurrentTotalNumberOfSlices();
     const maxOffset = totalSlices * sliceSize;
     // move content if needed
     if (indexOffset < maxOffset) {


### PR DESCRIPTION
 **Fix error while loading multiple single frame series**

Multiple single fram series were failing to load. When a new frame got added, we updated the image geometry too early before the frame's data was actually in the buffer. So the code that shifts slices around thought there was one more slice than there really was, stepped outside the valid data, and the load broke.